### PR TITLE
GFX Font characters - Opaque overlap characters

### DIFF
--- a/ILI9341_t3n.h
+++ b/ILI9341_t3n.h
@@ -497,6 +497,14 @@ class ILI9341_t3n : public Print
 	// GFX Font support
 	const GFXfont *gfxFont = nullptr;
 	int8_t _gfxFont_min_yOffset = 0;
+
+	// Opaque font chracter overlap?
+	unsigned int _gfx_c_last;
+	int16_t   _gfx_last_cursor_x, _gfx_last_cursor_y;
+	int16_t	 _gfx_last_char_x_write = 0;
+	uint16_t _gfx_last_char_textcolor;
+	uint16_t _gfx_last_char_textbgcolor;
+	bool gfxFontLastCharPosFG(int16_t x, int16_t y);
 	
 
   	uint8_t  _rst;


### PR DESCRIPTION
Now handles Opaque font output.

The code remembers the previous character output and how far it extended
as it might extend into the beginning of the next character to be
output.

Also checks to see if the xOffset for the character is negative, in
which case it might overwrite part of previous character.

Code for both Frame buffer and non frame buffer.  Frame buffer code is
simple in that it can simply look into the memory and say if the
previous char overwrote part of me, and I am about to output background
color, and the data at that pixel is the text color of previous char,
don't touch it...

For non-frame buffer code, it sets up one update rectangle for the whole
area that might be updated.  Again if the pixel I would output would be
my background color, I see if I am in the overlap area.  I then have the
code compute if the previous character would have set this to it's FG
color and then output that color.  If not, and I am before my current
text cursor, I output the previous characters BG color, else I output
the current characters BG color.