### PR TITLE
Move Font header to it's own header file and allow sharing of fonts between display types

### DIFF
--- a/ILI9341_fonts.h
+++ b/ILI9341_fonts.h
@@ -1,0 +1,26 @@
+// https://github.com/kurte/ILI9341_t3n
+// http://forum.pjrc.com/threads/26305-Highly-optimized-ILI9341-(320x240-TFT-color-display)-library
+//
+// ILI Font file definition.
+#ifndef _ILI9341_FONTS_H_
+#define _ILI9341_FONTS_H_
+typedef struct {
+	const unsigned char *index;
+	const unsigned char *unicode;
+	const unsigned char *data;
+	unsigned char version;
+	unsigned char reserved;
+	unsigned char index1_first;
+	unsigned char index1_last;
+	unsigned char index2_first;
+	unsigned char index2_last;
+	unsigned char bits_index;
+	unsigned char bits_width;
+	unsigned char bits_height;
+	unsigned char bits_xoffset;
+	unsigned char bits_yoffset;
+	unsigned char bits_delta;
+	unsigned char line_space;
+	unsigned char cap_height;
+} ILI9341_t3_font_t;
+#endif

--- a/ILI9341_t3n.h
+++ b/ILI9341_t3n.h
@@ -1,4 +1,4 @@
-// https://github.com/PaulStoffregen/ILI9341_t3n
+// https://github.com/kurte/ILI9341_t3n
 // http://forum.pjrc.com/threads/26305-Highly-optimized-ILI9341-(320x240-TFT-color-display)-library
 //
 // Warning this is Kurt's hacked up version whcih allow different SPI busses, which hopefully 
@@ -87,6 +87,8 @@
 #endif
 #include <stdint.h>
 
+#include "ILI9341_fonts.h"
+
 #define ILI9341_TFTWIDTH  240
 #define ILI9341_TFTHEIGHT 320
 
@@ -173,25 +175,6 @@
 
 #define sint16_t int16_t
 
-typedef struct {
-	const unsigned char *index;
-	const unsigned char *unicode;
-	const unsigned char *data;
-	unsigned char version;
-	unsigned char reserved;
-	unsigned char index1_first;
-	unsigned char index1_last;
-	unsigned char index2_first;
-	unsigned char index2_last;
-	unsigned char bits_index;
-	unsigned char bits_width;
-	unsigned char bits_height;
-	unsigned char bits_xoffset;
-	unsigned char bits_yoffset;
-	unsigned char bits_delta;
-	unsigned char line_space;
-	unsigned char cap_height;
-} ILI9341_t3_font_t;
 // Lets see about supporting Adafruit fonts as well?
 #ifndef _GFXFONT_H_
 #define _GFXFONT_H_

--- a/ILI9341_t3n.h
+++ b/ILI9341_t3n.h
@@ -240,6 +240,7 @@ class ILI9341_t3n : public Print
   	void sleep(bool enable);		
 	void pushColor(uint16_t color);
 	void fillScreen(uint16_t color);
+	inline void fillWindow(uint16_t color) {fillScreen(color);}
 	void drawPixel(int16_t x, int16_t y, uint16_t color);
 	void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
 	void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);

--- a/examples/ILI_Ada_FontTest3/ILI_Ada_FontTest3.ino
+++ b/examples/ILI_Ada_FontTest3/ILI_Ada_FontTest3.ino
@@ -1,0 +1,178 @@
+#include <Adafruit_GFX.h>
+
+#include <SPI.h>
+#include <ILI9341_t3n.h>
+
+#include "font_Arial.h"
+#include "font_ArialBold.h"
+#include "font_ComicSansMS.h"
+#include "font_OpenSans.h"
+#include "font_DroidSans.h"
+#include "font_Michroma.h"
+#include "font_Crystal.h"
+#include "font_ChanceryItalic.h"
+
+#define ILI9341_CS 10
+#define ILI9341_DC 9
+#define ILI9341_RST 8
+ILI9341_t3n tft = ILI9341_t3n(ILI9341_CS, ILI9341_DC, ILI9341_RST);
+uint8_t test_screen_rotation = 0;
+
+
+void setup() {
+  Serial.begin(38400);
+  long unsigned debug_start = millis ();
+  while (!Serial && ((millis () - debug_start) <= 5000)) ;
+  Serial.println("Setup");
+  tft.begin();
+
+  tft.setRotation(4);
+  tft.fillWindow(ILI9341_BLACK);
+
+  tft.setTextColor(ILI9341_WHITE);
+  tft.setFont(Arial_14);
+  tft.println("Arial_14");
+  displayStuff();
+
+  tft.setTextColor(ILI9341_YELLOW);
+  tft.setFont(Arial_14_Bold);
+  tft.println("ArialBold 14");
+  displayStuff();
+
+  tft.setTextColor(ILI9341_GREEN);
+  tft.setFont(ComicSansMS_14);
+  tft.println("ComicSansMS 14");
+  displayStuff(); 
+
+  nextPage();
+  
+  tft.setTextColor(ILI9341_WHITE);
+  tft.setFont(DroidSans_14);
+  tft.println("DroidSans_14");
+  displayStuff();
+
+  tft.setTextColor(ILI9341_YELLOW);
+  tft.setFont(Michroma_14);
+  tft.println("Michroma_14");
+  displayStuff();
+
+  tft.setTextColor(ILI9341_BLACK, ILI9341_YELLOW);
+  tft.setFont(Crystal_24_Italic);
+  tft.println("CRYSTAL_24");
+  displayStuff();
+
+  nextPage();
+
+  tft.setTextColor(ILI9341_GREEN);
+  tft.setFont(Chancery_24_Italic);
+  tft.println("Chancery_24_Italic");
+  displayStuff();
+
+  //anti-alias font OpenSans
+  tft.setTextColor(ILI9341_RED, ILI9341_YELLOW);
+  tft.setFont(OpenSans24);
+  tft.println("OpenSans 18");
+  displayStuff(); 
+  
+  Serial.println("Basic Font Display Complete");
+  Serial.println("Loop test for alt colors + font");
+}
+
+void loop()
+{
+  Serial.printf("\nRotation: %d\n", test_screen_rotation);
+  tft.setRotation(test_screen_rotation);
+  test_screen_rotation = (test_screen_rotation + 1) & 0x3;
+  
+  nextPage();
+
+  tft.setTextColor(ILI9341_WHITE);
+  tft.setFont(Arial_14);
+  tft.println("Arial_14");
+  displayStuff1();
+
+  tft.setTextColor(ILI9341_YELLOW);
+  tft.setFont(Arial_14_Bold);
+  tft.println("ArialBold 14");
+  displayStuff1();
+
+  nextPage();
+
+  tft.setTextColor(ILI9341_GREEN);
+  tft.setFont(ComicSansMS_14);
+  tft.println("ComicSansMS 14");
+  displayStuff1(); 
+
+  tft.setTextColor(ILI9341_WHITE);
+  tft.setFont(DroidSans_14);
+  tft.println("DroidSans_14");
+  displayStuff1();
+
+  nextPage();
+
+  tft.setTextColor(ILI9341_YELLOW);
+  tft.setFont(Michroma_14);
+  tft.println("Michroma_14");
+  displayStuff1();
+
+  nextPage();
+  
+  tft.setTextColor(ILI9341_BLACK, ILI9341_YELLOW);
+  tft.setFont(Crystal_24_Italic);
+  tft.println("CRYSTAL_24");
+  displayStuff1();
+
+  tft.setTextColor(ILI9341_GREEN);
+  tft.setFont(Chancery_24_Italic);
+  tft.println("Chancery_24_Italic");
+  displayStuff1();
+  
+  nextPage();
+
+  //anti-alias font OpenSans
+  tft.setTextColor(ILI9341_RED, ILI9341_YELLOW);
+  tft.setFont(OpenSans24);
+  tft.println("OpenSans 18");
+  displayStuff1(); 
+
+  nextPage();
+}
+
+uint32_t displayStuff()
+{
+  elapsedMillis elapsed_time = 0;
+  tft.println("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  tft.println("abcdefghijklmnopqrstuvwxyz");
+  tft.println("0123456789");
+  tft.println("!@#$%^ &*()-");
+  tft.println(); tft.println();
+  return (uint32_t) elapsed_time;
+}
+
+uint32_t displayStuff1()
+{
+  elapsedMillis elapsed_time = 0;
+  tft.println("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  tft.println("abcdefghijklmnopqrstuvwxyz");
+  tft.println("0123456789");
+  tft.println("!@#$%^ &*()-");
+  static const char alternating_text[] = "AbCdEfGhIjKlMnOpQrStUvWxYz\raBcDeFgHiJkLmNoPqRsTuVwXyZ";
+ 
+  for (uint8_t i = 0; i < sizeof(alternating_text); i++) {
+    if (i & 1) tft.setTextColor(ILI9341_WHITE, ILI9341_RED);
+    else tft.setTextColor(ILI9341_YELLOW, ILI9341_BLUE);
+    tft.write(alternating_text[i]);
+  }
+  tft.println(); tft.println();
+  return (uint32_t) elapsed_time;
+}
+
+void nextPage()
+{
+  Serial.println("Press anykey to continue");
+  while (Serial.read() == -1) ;
+  while (Serial.read() != -1) ;
+
+  tft.fillWindow(ILI9341_BLACK);
+  tft.setCursor(0, 0);
+}

--- a/ili9341_t3n_font_Arial.h
+++ b/ili9341_t3n_font_Arial.h
@@ -1,7 +1,7 @@
 #ifndef _ILI9341_t3n_font_Arial_
 #define _ILI9341_t3n_font_Arial_
 
-#include "ILI9341_t3n.h"
+#include "ILI9341_fonts.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ili9341_t3n_font_ArialBold.h
+++ b/ili9341_t3n_font_ArialBold.h
@@ -1,7 +1,7 @@
 #ifndef _ILI9341_t3n_font_ArialBold_
 #define _ILI9341_t3n_font_ArialBold_
 
-#include "ILI9341_t3n.h"
+#include "ILI9341_fonts.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ili9341_t3n_font_ComicSansMS.h
+++ b/ili9341_t3n_font_ComicSansMS.h
@@ -1,7 +1,7 @@
 #ifndef _ILI9341_t3n_font_ComicSansMS_
 #define _ILI9341_t3n_font_ComicSansMS_
 
-#include "ILI9341_t3n.h"
+#include "ILI9341_fonts.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ili9341_t3n_font_OpenSans.h
+++ b/ili9341_t3n_font_OpenSans.h
@@ -1,7 +1,7 @@
 #ifndef _ILI9341_t3_font_OpenSans_
 #define _ILI9341_t3_font_OpenSans_
 
-#include "ILI9341_t3n.h"
+#include "ILI9341_fonts.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Extracted the ILI font definition used with ILI9341_t3 library to be it's own header file, instead of combined into the main ili9341_t3n library.  This way we can simply duplicate that header to other display libraries, and then be able to use the same font files in several different displays without having to edit them.

Added font example that came from our testing of the RA8875 library, which shows several of these font's 