### PR TITLE
Center text like RA8875

### DIFF
--- a/ILI9341_t3n.h
+++ b/ILI9341_t3n.h
@@ -333,7 +333,8 @@ class ILI9341_t3n : public Print
 	void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color, uint16_t bg, uint8_t size_x, uint8_t size_y);
 	void inline drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color, uint16_t bg, uint8_t size) 
 	    { drawChar(x, y, c, color, bg, size);}
-	void setCursor(int16_t x, int16_t y);
+	static const int16_t CENTER = 9998;
+	void setCursor(int16_t x, int16_t y, bool autoCenter=false);
     void getCursor(int16_t *x, int16_t *y);
 	void setTextColor(uint16_t c);
 	void setTextColor(uint16_t c, uint16_t bg);
@@ -368,7 +369,10 @@ class ILI9341_t3n : public Print
 			 updateDisplayClip(); 
 		}
 
+	// overwrite print functions:
 	virtual size_t write(uint8_t);
+	virtual size_t write(const uint8_t *buffer, size_t size);
+
 	int16_t width(void)  { return _width; }
 	int16_t height(void) { return _height; }
 	uint8_t getRotation(void);
@@ -382,6 +386,8 @@ class ILI9341_t3n : public Print
 	void drawFontChar(unsigned int c);
 	void drawGFXFontChar(unsigned int c);
 
+    void getTextBounds(const uint8_t *buffer, uint16_t len, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
     void getTextBounds(const char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
     void getTextBounds(const String &str, int16_t x, int16_t y,
@@ -450,7 +456,8 @@ class ILI9341_t3n : public Print
 
 	int16_t _width, _height; // Display w/h as modified by current rotation
 	int16_t  cursor_x, cursor_y;
-
+	bool 	_center_x_text = false; 
+	bool 	_center_y_text = false; 
 	int16_t  _clipx1, _clipy1, _clipx2, _clipy2;
 	int16_t  _originx, _originy;
 	int16_t  _displayclipx1, _displayclipy1, _displayclipx2, _displayclipy2;
@@ -567,6 +574,7 @@ class ILI9341_t3n : public Print
 	  // as to move it out of the memory that is cached...
 
 	static const uint32_t _count_pixels = ILI9341_TFTWIDTH * ILI9341_TFTHEIGHT;
+
 	DMASetting   		_dmasettings[2];
 	DMAChannel   		_dmatx;
 	volatile    uint32_t _dma_pixel_index = 0;

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ have one CS pin unless you use some form of adapter to use the SPI pins that are
 
 Frame Buffer
 ------------
-The teensy 3.6 and now 3.5 have a lot more memory than previous Teensy processors, so on these boards, I borrowed some ideas from the ILI9341_t3DMA library and added code to be able to use a logical Frame Buffer.  To enable this I added a couple of API's 
-
+The teensy 3.6 and now 3.5 and now the T4.0 have a lot more memory than previous Teensy processors, so on these boards, I borrowed some ideas from the ILI9341_t3DMA library and added code to be able to use a logical Frame Buffer.  To enable this I added a couple of API's 
+```c++
     uint8_t useFrameBuffer(boolean b) - if b non-zero it will allocate memory and start using
     void	freeFrameBuffer(void) - Will free up the memory that was used.
     void	updateScreen(void); - Will update the screen with all of your updates...
 	void	setFrameBuffer(uint16_t *frame_buffer); - Now have the ability allocate the frame buffer and pass it in, to avoid use of malloc
-
+```
 Asynchronous Update support (Frame buffer)
 ------------------------
 
@@ -42,21 +42,41 @@ The code now has support to use DMA for Asynchronous updates of the screen.  You
 oneshot as I prefer more control on when the screen updates which helps to minimize things like flashing and tearing. 
 Some of the New methods for this include: 
 
-
+```c++
 	bool	updateScreenAsync(bool update_cont = false); - Starts an update either one shot or continuous
 	void	waitUpdateAsyncComplete(void);  - Wait for any active update to complete
 	void	endUpdateAsync();			 - Turn of the continuous mode.
 	boolean	asyncUpdateActive(void)      - Lets you know if an async operation is still active
-
+```
 
 Additional APIs
 ---------------
 In addition, this library now has some of the API's and functionality that has been requested in a pull request.  In particular it now supports, the ability to set a clipping rectangle as well as setting an origin that is used with the drawing primitives.   These new API's include:
-
+```c++
 	void setOrigin(int16_t x = 0, int16_t y = 0); 
 	void getOrigin(int16_t* x, int16_t* y);
 	void setClipRect(int16_t x1, int16_t y1, int16_t w, int16_t h); 
 	void setClipRect();
+```
+
+This library borrows some concepts and functionality from other libraries as well, such as: from the TFT_ILI9341_ESP, https://github.com/Bodmer/TFT_ILI9341_ESP, for additional functions:
+```c++
+    int16_t  drawNumber(long long_num,int poX, int poY);
+    int16_t  drawFloat(float floatNumber,int decimal,int poX, int poY);   
+    int16_t drawString(const String& string, int poX, int poY);
+    int16_t drawString1(char string[], int16_t len, int poX, int poY);
+    void setTextDatum(uint8_t datum);
+```
+
+In addition, scrolling text has been added using appropriate function from, https://github.com/vitormhenrique/ILI9341_t3:
+```c++
+    void enableScroll(void);
+    void resetScrollBackgroundColor(uint16_t color);
+    void setScrollTextArea(int16_t x, int16_t y, int16_t w, int16_t h);
+    void setScrollBackgroundColor(uint16_t color);
+    void scrollTextArea(uint8_t scrollSize);
+    void resetScrollBackgroundColor(uint16_t color);
+```
 
 Font Support
 ------------
@@ -64,6 +84,17 @@ This library tries to support three different font types.  This includes the ori
 built in system font, as well as the new font format. 
 
 In addition, we added support to use the Adafruit GFX fonts as well. This includes the ability to output the text in Opaque mode. 
+
+The text output support also has been exteneded in a way similar to the RA8875 library to allow for easier centering of text. 
+
+The member function setCursor has been extended in a couple of ways:
+```c++
+	void setCursor(int16_t x, int16_t y, bool autoCenter=false);
+```
+if the autoCenter is true, the next text output will be centered at the given x, y location.  Note: this is only true for the NEXT output.  
+
+In addition you can pass in the magic value: ILI9341_t3n::CENTER for x and/or y and the next text output will be centered horizontally and/or vertically centered in the screen. 
+
 
 Discussion regarding this optimized version:
 ==========================
@@ -109,8 +140,6 @@ Also requires the Adafruit_GFX library for Arduino.
 Future Updates
 ==============
 
-I am hoping to phase out SPIN and be able to directly use SPI.  This has been helped by the recent updates to SPI, which all of the SPI objects are of one class. Currently I 
-still need a few additional things like pointers to the underlying SPI registers.  But hopefully will get there. 
 
 Again WIP
 =====

--- a/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
+++ b/examples/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
@@ -1,0 +1,232 @@
+#include <Adafruit_GFX.h>
+
+#include <SPI.h>
+#include <ILI9341_t3n.h>
+
+#include "font_Arial.h"
+#include "font_ArialBold.h"
+#include "font_ComicSansMS.h"
+#include "font_OpenSans.h"
+#include "font_DroidSans.h"
+#include "font_Michroma.h"
+#include "font_Crystal.h"
+#include "font_ChanceryItalic.h"
+
+#define CENTER ILI9341_t3n::CENTER
+
+// maybe a few GFX FOnts?
+#include <Fonts/FreeMonoBoldOblique12pt7b.h>
+#include <Fonts/FreeSerif12pt7b.h>
+
+typedef struct {
+  const ILI9341_t3_font_t *ili_font;
+  const GFXfont       *gfx_font;
+  const char          *font_name;
+  uint16_t            font_fg_color;
+  uint16_t            font_bg_color;
+} ili_fonts_test_t;
+
+
+const ili_fonts_test_t font_test_list[] = {
+  {&Arial_14, nullptr,  "Arial_14", ILI9341_WHITE, ILI9341_WHITE},
+  {&Arial_14_Bold, nullptr,  "ArialBold 14", ILI9341_YELLOW, ILI9341_YELLOW},
+  {&ComicSansMS_14, nullptr,  "ComicSansMS 14", ILI9341_GREEN, ILI9341_GREEN},
+  {&DroidSans_14, nullptr,  "DroidSans_14", ILI9341_WHITE, ILI9341_WHITE},
+  {&Michroma_14, nullptr,  "Michroma_14", ILI9341_YELLOW, ILI9341_YELLOW},
+  {&Crystal_24_Italic, nullptr,  "CRYSTAL_24", ILI9341_BLACK, ILI9341_YELLOW},
+  {&Chancery_24_Italic, nullptr,  "Chancery_24_Italic", ILI9341_GREEN, ILI9341_GREEN},
+  {&OpenSans24, nullptr,  "OpenSans 18", ILI9341_RED, ILI9341_YELLOW},
+  {nullptr, &FreeMonoBoldOblique12pt7b,  "GFX FreeMonoBoldOblique12pt7b", ILI9341_WHITE, ILI9341_WHITE},
+  {nullptr, &FreeMonoBoldOblique12pt7b,  "GFX FreeMonoBoldOblique12pt7b", ILI9341_RED, ILI9341_YELLOW},
+  {nullptr, &FreeSerif12pt7b,  "GFX FreeSerif12pt7b", ILI9341_WHITE, ILI9341_WHITE},
+  {nullptr, &FreeSerif12pt7b,  "GFX FreeSerif12pt7b", ILI9341_RED, ILI9341_YELLOW},
+
+} ;
+
+
+
+#define ILI9341_CS 10
+#define ILI9341_DC 9
+#define ILI9341_RST 8
+ILI9341_t3n tft = ILI9341_t3n(ILI9341_CS, ILI9341_DC, ILI9341_RST);
+uint8_t test_screen_rotation = 0;
+
+
+void setup() {
+  Serial.begin(38400);
+  long unsigned debug_start = millis ();
+  while (!Serial && ((millis () - debug_start) <= 5000)) ;
+  Serial.println("Setup");
+  //  begin display: Choose from: ILI9341_480x272, ILI9341_800x480, ILI9341_800x480ALT, Adafruit_480x272, Adafruit_800x480
+  tft.begin(60000000u);
+
+  tft.setRotation(4);
+  tft.fillWindow(ILI9341_BLACK);
+
+  tft.setTextColor(ILI9341_WHITE);
+  tft.setFont(Arial_14);
+  tft.println("Arial_14");
+  displayStuff();
+
+  tft.setTextColor(ILI9341_YELLOW);
+  tft.setFont(Arial_14_Bold);
+  tft.println("ArialBold 14");
+  displayStuff();
+  nextPage();
+  tft.setTextColor(ILI9341_GREEN);
+  tft.setFont(ComicSansMS_14);
+  tft.println("ComicSansMS 14");
+  displayStuff();
+
+
+  tft.setTextColor(ILI9341_WHITE);
+  tft.setFont(DroidSans_14);
+  tft.println("DroidSans_14");
+  displayStuff();
+  nextPage();
+
+  tft.setTextColor(ILI9341_YELLOW);
+  tft.setFont(Michroma_14);
+  tft.println("Michroma_14");
+  displayStuff();
+
+  tft.setTextColor(ILI9341_BLACK, ILI9341_YELLOW);
+  tft.setFont(Crystal_24_Italic);
+  tft.println("CRYSTAL_24");
+  displayStuff();
+
+  nextPage();
+
+  tft.setTextColor(ILI9341_GREEN);
+  tft.setFont(Chancery_24_Italic);
+  tft.println("Chancery_24_Italic");
+  displayStuff();
+
+  //anti-alias font OpenSans
+  tft.setTextColor(ILI9341_RED, ILI9341_YELLOW);
+  tft.setFont(OpenSans24);
+  tft.println("OpenSans 18");
+  displayStuff();
+
+  Serial.println("Basic Font Display Complete");
+  Serial.println("Loop test for alt colors + font");
+}
+
+void loop()
+{
+  tft.setFont(Arial_12);
+  Serial.printf("\nRotation: %d\n", test_screen_rotation);
+  tft.setRotation(test_screen_rotation);
+  tft.fillWindow(ILI9341_RED);
+  tft.setCursor(CENTER, CENTER);
+  tft.printf("Rotation: %d", test_screen_rotation);
+  test_screen_rotation = (test_screen_rotation + 1) & 0x3;
+  /*  tft.setCursor(200, 300);
+    Serial.printf("  Set cursor(200, 300), retrieved(%d %d)",
+                  tft.getCursorX(), tft.getCursorY());
+  */
+  tft.setCursor(25, 25);
+  tft.write('0');
+  tft.setCursor(tft.width() - 25, 25);
+  tft.write('1');
+  tft.setCursor(25, tft.height() - 25);
+  tft.write('2');
+  tft.setCursor(tft.width() - 25, tft.height() - 25);
+  tft.write('3');
+
+  for (uint8_t font_index = 0; font_index < (sizeof(font_test_list) / sizeof(font_test_list[0])); font_index++) {
+    nextPage();
+    if (font_test_list[font_index].font_fg_color != font_test_list[font_index].font_bg_color)
+      tft.setTextColor(font_test_list[font_index].font_fg_color, font_test_list[font_index].font_bg_color);
+    else
+      tft.setTextColor(font_test_list[font_index].font_fg_color);
+    if (font_test_list[font_index].ili_font) tft.setFont(*font_test_list[font_index].ili_font);
+    else tft.setFont(font_test_list[font_index].gfx_font);
+    tft.println(font_test_list[font_index].font_name);
+    displayStuff1();
+  }
+  nextPage();
+}
+
+uint32_t displayStuff()
+{
+  elapsedMillis elapsed_time = 0;
+  tft.println("ABCDEFGHIJKLM");
+  tft.println("nopqrstuvwxyz");
+  tft.println("0123456789");
+  tft.println("!@#$%^ &*()-");
+  tft.println(); tft.println();
+  return (uint32_t) elapsed_time;
+}
+
+uint32_t displayStuff1()
+{
+  elapsedMillis elapsed_time = 0;
+  tft.println("ABCDEFGHIJKLM");
+  tft.println("nopqrstuvwxyz");
+  tft.println("0123456789");
+  tft.println("!@#$%^ &*()-");
+
+  int16_t cursorX = tft.getCursorX();
+  int16_t cursorY = tft.getCursorY();
+
+  uint16_t width = tft.width();
+  uint16_t height = tft.height();
+  Serial.printf("DS1 (%d,%d) %d %d\n", cursorX, cursorY, width, height);
+  uint16_t rect_x = width / 2 - 50;
+  uint16_t rect_y = height - 50;
+  tft.drawRect(rect_x, rect_y, 100, 40, ILI9341_WHITE);
+  for (uint16_t y = rect_y + 5; y < rect_y + 40; y += 5)
+    tft.drawFastHLine(rect_x + 1, y, 98, ILI9341_PINK);
+  for (uint16_t x = rect_x + 5; x < rect_x + 100; x += 5)
+    tft.drawFastVLine(x, rect_y + 1, 38, ILI9341_PINK);
+  tft.setCursor(width / 2, height - 30, true);
+  tft.print("Center");
+
+  // Lets try again with CENTER X keyword.
+  rect_y -= 60;
+  tft.drawRect(rect_x, rect_y, 100, 40, ILI9341_PINK);
+  for (uint16_t y = rect_y + 5; y < rect_y + 40; y += 5)
+    tft.drawFastHLine(rect_x + 1, y, 98, ILI9341_CYAN);
+  for (uint16_t x = rect_x + 5; x < rect_x + 100; x += 5)
+    tft.drawFastVLine(x, rect_y + 1, 38, ILI9341_CYAN);
+  tft.setCursor(CENTER, rect_y);
+  tft.print("XCENTR");
+
+  // Lets try again with CENTER Y keyword.
+  rect_x = 50;
+  rect_y = tft.height() / 2 - 25;
+  tft.drawRect(rect_x, rect_y, 100, 50, ILI9341_CYAN);
+  for (uint16_t y = rect_y + 5; y < rect_y + 50; y += 5)
+    tft.drawFastHLine(rect_x + 1, y, 98, ILI9341_PINK);
+  for (uint16_t x = rect_x + 5; x < rect_x + 100; x += 5)
+    tft.setCursor(50, CENTER);
+  tft.print("YCENTR");
+
+
+
+  tft.setCursor(cursorX, cursorY);
+  static const char alternating_text[] = "AbCdEfGhIjKlM\rNoPqRsTuVwXyZ";
+
+  for (uint8_t i = 0; i < (sizeof(alternating_text) - 1); i++) {
+    if (i & 1) tft.setTextColor(ILI9341_WHITE, ILI9341_RED);
+    else tft.setTextColor(ILI9341_YELLOW, ILI9341_BLUE);
+    tft.write(alternating_text[i]);
+  }
+
+  tft.println(); tft.println();
+
+
+
+  return (uint32_t) elapsed_time;
+}
+
+void nextPage()
+{
+  Serial.println("Press anykey to continue");
+  while (Serial.read() == -1) ;
+  while (Serial.read() != -1) ;
+
+  tft.fillWindow(ILI9341_BLACK);
+  tft.setCursor(0, 0);
+}


### PR DESCRIPTION
Added support to the member method setCursor to optionally be able to
tell system to center the text horizontally and/or vertically at the
position passed in or the center of the screen.

That is:
```
tft.setCursor(100, 100, true);
tft.print("Center");
```
Will center the text "center" at location 100, 100

Also have ability to set X and or Y to be centered at center of screen.
```
tft.setCursor(ILI9341_t3n::CENTER, 100);
tft.print("zzz");
```
Will print zzz starting at y location 100 with the text centered
horzontally .

And similar for:
```
tft.setCursor(100, ILI9341_t3n::CENTER);
tft.print("yyy");
```
Where again yyy is printed with the text centered vertically on screen
start at x 100...