### PR TITLE
Experiment update only changed areas

### DIFF
--- a/ILI9341_t3n.cpp
+++ b/ILI9341_t3n.cpp
@@ -2075,7 +2075,7 @@ void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read)
 		}
 	}
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x 
-	Serial.println("   T4 setup CS/DC"); Serial.flush();
+	// Serial.println("   T4 setup CS/DC"); Serial.flush();
 	_csport = portOutputRegister(_cs);
 	_cspinmask = digitalPinToBitMask(_cs);
 	pinMode(_cs, OUTPUT);	
@@ -2085,7 +2085,7 @@ void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read)
 	// TODO:  Need to setup DC to actually work.
 	if (_pspi->pinIsChipSelect(_dc)) {
 	 	uint8_t dc_cs_index = _pspi->setCS(_dc);
-	 	Serial.printf("    T4 hardware DC: %x\n", dc_cs_index);
+	 	// Serial.printf("    T4 hardware DC: %x\n", dc_cs_index);
 	 	_dcport = 0;
 	 	_dcpinmask = 0;
 	 	// will depend on which PCS but first get this to work...
@@ -2093,7 +2093,7 @@ void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read)
 		_tcr_dc_assert = LPSPI_TCR_PCS(dc_cs_index);
     	_tcr_dc_not_assert = LPSPI_TCR_PCS(3);
 	} else {
-		Serial.println("ILI9341_t3n: DC is not valid hardware CS pin");
+		//Serial.println("ILI9341_t3n: DC is not valid hardware CS pin");
 		_dcport = portOutputRegister(_dc);
 		_dcpinmask = digitalPinToBitMask(_dc);
 		pinMode(_dc, OUTPUT);	

--- a/ILI9341_t3n.cpp
+++ b/ILI9341_t3n.cpp
@@ -812,6 +812,7 @@ void ILI9341_t3n::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y);		// update the range of the screen that has been changed;
 		_pfbtft[y*_width + x] = color;
 
 	} else 
@@ -837,6 +838,7 @@ void ILI9341_t3n::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, 1, h);		// update the range of the screen that has been changed;
 		uint16_t * pfbPixel = &_pfbtft[ y*_width + x];
 		while (h--) {
 			*pfbPixel = color;
@@ -869,6 +871,7 @@ void ILI9341_t3n::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color)
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, 1);		// update the range of the screen that has been changed;
 		if ((x&1) || (w&1)) {
 			uint16_t * pfbPixel = &_pfbtft[ y*_width + x];
 			while (w--) {
@@ -902,6 +905,7 @@ void ILI9341_t3n::fillScreen(uint16_t color)
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft && _standard) {
 		// Speed up lifted from Franks DMA code... _standard is if no offsets and rects..
+		updateChangedRange(0, 0, _width, _height);		// update the range of the screen that has been changed;
 		uint32_t color32 = (color << 16) | color;
 
 		uint32_t *pfbPixel = (uint32_t *)_pfbtft;
@@ -940,6 +944,7 @@ void ILI9341_t3n::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t 
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, h);		// update the range of the screen that has been changed;
 		if ((x&1) || (w&1)) {
 			uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 			for (;h>0; h--) {
@@ -1009,6 +1014,7 @@ void ILI9341_t3n::fillRectVGradient(int16_t x, int16_t y, int16_t w, int16_t h, 
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, h);		// update the range of the screen that has been changed;
 		if ((x&1) || (w&1)) {
 			uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 			for (;h>0; h--) {
@@ -1079,6 +1085,7 @@ void ILI9341_t3n::fillRectHGradient(int16_t x, int16_t y, int16_t w, int16_t h, 
 	r=r1;g=g1;b=b1;	
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, h);		// update the range of the screen that has been changed;
 		uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 		for (;h>0; h--) {
 			uint16_t * pfbPixel = pfbPixel_row;
@@ -1705,6 +1712,7 @@ void ILI9341_t3n::writeRect(int16_t x, int16_t y, int16_t w, int16_t h, const ui
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, h);		// update the range of the screen that has been changed;
 		uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 		for (;h>0; h--) {
 			uint16_t * pfbPixel = pfbPixel_row;
@@ -1777,6 +1785,7 @@ void ILI9341_t3n::writeRect8BPP(int16_t x, int16_t y, int16_t w, int16_t h, cons
 	//Serial.printf("WR8C: %d %d %d %d %x- %d %d\n", x, y, w, h, (uint32_t)pixels, x_clip_right, x_clip_left);
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, h);		// update the range of the screen that has been changed;
 		uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 		for (;h>0; h--) {
 			pixels += x_clip_left;
@@ -1894,6 +1903,7 @@ void ILI9341_t3n::writeRectNBPP(int16_t x, int16_t y, int16_t w, int16_t h,  uin
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
+		updateChangedRange(x, y, w, h);		// update the range of the screen that has been changed;
 		uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 		for (;h>0; h--) {
 			uint16_t * pfbPixel = pfbPixel_row;
@@ -2726,7 +2736,7 @@ void ILI9341_t3n::drawChar(int16_t x, int16_t y, unsigned char c,
 
 		#ifdef ENABLE_ILI9341_FRAMEBUFFER
 		if (_use_fbtft) {
-
+			updateChangedRange(x, y, 6 * size_x , 8 * size_y);		// update the range of the screen that has been changed;
 			uint16_t * pfbPixel_row = &_pfbtft[ y*_width + x];
 			for (yc=0; (yc < 8) && (y < _displayclipy2); yc++) {
 				for (yr=0; (yr < size_y) && (y < _displayclipy2); yr++) {
@@ -3140,6 +3150,8 @@ void ILI9341_t3n::drawFontChar(unsigned int c)
 */
 		#ifdef ENABLE_ILI9341_FRAMEBUFFER
 		if (_use_fbtft) {
+			updateChangedRange(start_x, start_y);		// update the range of the screen that has been changed;
+			updateChangedRange(end_x, end_y);		// update the range of the screen that has been changed;
 			uint16_t * pfbPixel_row = &_pfbtft[ start_y*_width + start_x];
 			uint16_t * pfbPixel;
 			int screen_y = start_y;
@@ -3865,6 +3877,8 @@ void ILI9341_t3n::drawGFXFontChar(unsigned int c) {
 		#ifdef ENABLE_ILI9341_FRAMEBUFFER
 		if (_use_fbtft) {
 			// lets try to output the values directly...
+			updateChangedRange(x_start, y_start);		// update the range of the screen that has been changed;
+			updateChangedRange(x_end, y_end);		// update the range of the screen that has been changed;
 			uint16_t * pfbPixel_row = &_pfbtft[ y_start *_width + x_start];
 			uint16_t * pfbPixel;
 			// First lets fill in the top parts above the actual rectangle...

--- a/ILI9341_t3n.cpp
+++ b/ILI9341_t3n.cpp
@@ -175,7 +175,7 @@ void ILI9341_t3n::process_dma_interrupt(void) {
 			_pimxrt_spi->SR = 0x3f00;	// clear out all of the other status...
 
 
-			maybeUpdateTCR(LPSPI_TCR_PCS(0) | LPSPI_TCR_FRAMESZ(7));	// output Command with 8 bits
+			maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7));	// output Command with 8 bits
 			// Serial.printf("Output NOP (SR %x CR %x FSR %x FCR %x %x TCR:%x)\n", _pimxrt_spi->SR, _pimxrt_spi->CR, _pimxrt_spi->FSR, 
 			//	_pimxrt_spi->FCR, _spi_fcr_save, _pimxrt_spi->TCR);
 			writecommand_last(ILI9341_NOP);
@@ -343,6 +343,7 @@ uint8_t ILI9341_t3n::useFrameBuffer(boolean b)		// use the frame buffer?  First 
 			memset(_pfbtft, 0, CBALLOC);	
 		}
 		_use_fbtft = 1;
+		clearChangedRange();	// make sure the dirty range is updated.
 	} else 
 		_use_fbtft = 0;
 
@@ -370,7 +371,7 @@ void ILI9341_t3n::updateScreen(void)					// call to say update the screen now.
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
 	if (_use_fbtft) {
 		beginSPITransaction(_SPI_CLOCK);
-		if (_standard) {
+		if (_standard && !_updateChangedAreasOnly) {
 			// Doing full window. 
 			setAddr(0, 0, _width-1, _height-1);
 			writecommand_cont(ILI9341_RAMWR);
@@ -386,27 +387,44 @@ void ILI9341_t3n::updateScreen(void)					// call to say update the screen now.
 			}
 			writedata16_last(*pftbft);
 		} else {
-			// setup just to output the clip rectangle area. 
-			setAddr(_displayclipx1, _displayclipy1, _displayclipx2-1, _displayclipy2-1);
-			writecommand_cont(ILI9341_RAMWR);
+			// setup just to output the clip rectangle area anded with updated area if enabled
+			int16_t start_x = _displayclipx1;
+			int16_t start_y = _displayclipy1;
+			int16_t end_x = _displayclipx2 - 1; 
+			int16_t end_y = _displayclipy2 - 1;
 
-			// BUGBUG doing as one shot.  Not sure if should or not or do like
-			// main code and break up into transactions...
-			uint16_t * pfbPixel_row = &_pfbtft[ _displayclipy1*_width + _displayclipx1];
-			for (uint16_t y = _displayclipy1; y < _displayclipy2; y++) {
-				uint16_t * pfbPixel = pfbPixel_row;
-				for (uint16_t x = _displayclipx1; x < (_displayclipx2-1); x++) {
-					writedata16_cont(*pfbPixel++);
+			if (_updateChangedAreasOnly) {
+				// maybe update range of values to update...
+	 			if (_changed_min_x > start_x) start_x = _changed_min_x;
+	 			if (_changed_min_y > start_y) start_y = _changed_min_y;
+	 			if (_changed_max_x < end_x) end_x = _changed_max_x;
+	 			if (_changed_max_y < end_y) end_y = _changed_max_y;
+			}
+
+			// Only do if actual area to update
+			if ((start_x <= end_x) && (start_y <= end_y)) {
+				setAddr(start_x, start_y, end_x, end_y);
+				writecommand_cont(ILI9341_RAMWR);
+
+				// BUGBUG doing as one shot.  Not sure if should or not or do like
+				// main code and break up into transactions...
+				uint16_t * pfbPixel_row = &_pfbtft[ start_y*_width + start_x];
+				for (uint16_t y = start_y; y <= end_y; y++) {
+					uint16_t * pfbPixel = pfbPixel_row;
+					for (uint16_t x = start_x; x < end_x; x++) {
+						writedata16_cont(*pfbPixel++);
+					}
+					if (y < (end_y))
+						writedata16_cont(*pfbPixel);
+					else	
+						writedata16_last(*pfbPixel);
+					pfbPixel_row += _width;	// setup for the next row. 
 				}
-				if (y < (_displayclipy2-1))
-					writedata16_cont(*pfbPixel);
-				else	
-					writedata16_last(*pfbPixel);
-				pfbPixel_row += _width;	// setup for the next row. 
 			}
 		}
 		endSPITransaction();
 	}
+	clearChangedRange();	// make sure the dirty range is updated.	
 	#endif
 }			 
 
@@ -672,7 +690,7 @@ bool ILI9341_t3n::updateScreenAsync(bool update_cont)					// call to say update 
 	// Update TCR to 16 bit mode. and output the first entry.
 	_spi_fcr_save = _pimxrt_spi->FCR;	// remember the FCR
 	_pimxrt_spi->FCR = 0;	// clear water marks... 	
-	maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(15) | LPSPI_TCR_RXMSK /*| LPSPI_TCR_CONT*/);
+	maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(15) | LPSPI_TCR_RXMSK /*| LPSPI_TCR_CONT*/);
  	_pimxrt_spi->DER = LPSPI_DER_TDDE;
 	_pimxrt_spi->SR = 0x3f00;	// clear out all of the other status...
 
@@ -1345,21 +1363,21 @@ uint8_t ILI9341_t3n::readcommand8(uint8_t c, uint8_t index)
 
     beginSPITransaction(_SPI_CLOCK_READ);
     // Lets assume that queues are empty as we just started transaction.
-	_pimxrt_spi->CR = LPSPI_CR_MEN | LPSPI_CR_RRF | LPSPI_CR_RTF;   // actually clear both...
+	_pimxrt_spi->CR = LPSPI_CR_MEN | LPSPI_CR_RRF /* | LPSPI_CR_RTF */;   // actually clear both...
     //writecommand(0xD9); // sekret command
-    maybeUpdateTCR(LPSPI_TCR_PCS(0) | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
+    maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
 	_pimxrt_spi->TDR = 0xD9;
 
     // writedata(0x10 + index);
-	maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
+	maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
 	_pimxrt_spi->TDR = 0x10 + index;
 
     // writecommand(c);
-    maybeUpdateTCR(LPSPI_TCR_PCS(0) | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
+    maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
 	_pimxrt_spi->TDR = c;
 
     // readdata
-	maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(7));
+	maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
 	_pimxrt_spi->TDR = 0;
 
     // Now wait until completed.
@@ -1575,7 +1593,7 @@ void ILI9341_t3n::readRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t 
 			if (txCount) {
 				_pimxrt_spi->TDR = 0;
 			} else {
-				maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(7)); // remove the CONTINUE...
+				maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7)); // remove the CONTINUE...
 				while ((_pimxrt_spi->SR & LPSPI_SR_TDF) == 0) ;		// wait if queue was full
 				_pimxrt_spi->TDR = 0;
 			}
@@ -2066,17 +2084,25 @@ void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read)
 
 	// TODO:  Need to setup DC to actually work.
 	if (_pspi->pinIsChipSelect(_dc)) {
-	 	_pspi->setCS(_dc);
+	 	uint8_t dc_cs_index = _pspi->setCS(_dc);
+	 	Serial.printf("    T4 hardware DC: %x\n", dc_cs_index);
 	 	_dcport = 0;
 	 	_dcpinmask = 0;
+	 	// will depend on which PCS but first get this to work...
+	 	dc_cs_index--;	// convert to 0 based
+		_tcr_dc_assert = LPSPI_TCR_PCS(dc_cs_index);
+    	_tcr_dc_not_assert = LPSPI_TCR_PCS(3);
 	} else {
-		//Serial.println("ILI9341_t3n: Error not DC is not valid hardware CS pin");
+		Serial.println("ILI9341_t3n: DC is not valid hardware CS pin");
 		_dcport = portOutputRegister(_dc);
 		_dcpinmask = digitalPinToBitMask(_dc);
 		pinMode(_dc, OUTPUT);	
 		DIRECT_WRITE_HIGH(_dcport, _dcpinmask);
+		_tcr_dc_assert = LPSPI_TCR_PCS(0);
+    	_tcr_dc_not_assert = LPSPI_TCR_PCS(1);
+
 	}
-	maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(7));
+	maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
 
 #else
 	// TLC

--- a/ILI9341_t3n.h
+++ b/ILI9341_t3n.h
@@ -542,6 +542,8 @@ class ILI9341_t3n : public Print
     volatile uint32_t *_csport;
     uint32_t _spi_tcr_current;
     uint32_t _dcpinmask;
+    uint32_t _tcr_dc_assert;
+    uint32_t _tcr_dc_not_assert;
     volatile uint32_t *_dcport;
 #else
     uint8_t _cspinmask;
@@ -627,6 +629,9 @@ class ILI9341_t3n : public Print
 
 	void beginSPITransaction(uint32_t clock) __attribute__((always_inline)) {
 		_pspi->beginTransaction(SPISettings(clock, MSBFIRST, SPI_MODE0));
+		#if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x 
+		if (!_dcport) _spi_tcr_current = _pimxrt_spi->TCR; 	// Only if DC is on hardware CS 
+		#endif
 		if (_csport) {
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x 
 			DIRECT_WRITE_LOW(_csport, _cspinmask);
@@ -696,39 +701,39 @@ class ILI9341_t3n : public Print
 
 	// BUGBUG:: currently assumming we only have CS_0 as valid CS
 	void writecommand_cont(uint8_t c) __attribute__((always_inline)) {
-		maybeUpdateTCR(LPSPI_TCR_PCS(0) | LPSPI_TCR_FRAMESZ(7) /*| LPSPI_TCR_CONT*/);
+		maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7) /*| LPSPI_TCR_CONT*/);
 		_pimxrt_spi->TDR = c;
 		pending_rx_count++;	//
 		waitFifoNotFull();
 	}
 	void writedata8_cont(uint8_t c) __attribute__((always_inline)) {
-		maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
+		maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
 		_pimxrt_spi->TDR = c;
 		pending_rx_count++;	//
 		waitFifoNotFull();
 	}
 	void writedata16_cont(uint16_t d) __attribute__((always_inline)) {
-		maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(15) | LPSPI_TCR_CONT);
+		maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(15) | LPSPI_TCR_CONT);
 		_pimxrt_spi->TDR = d;
 		pending_rx_count++;	//
 		waitFifoNotFull();
 	}
 	void writecommand_last(uint8_t c) __attribute__((always_inline)) {
-		maybeUpdateTCR(LPSPI_TCR_PCS(0) | LPSPI_TCR_FRAMESZ(7));
+		maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7));
 		_pimxrt_spi->TDR = c;
 //		_pimxrt_spi->SR = LPSPI_SR_WCF | LPSPI_SR_FCF | LPSPI_SR_TCF;
 		pending_rx_count++;	//
 		waitTransmitComplete();
 	}
 	void writedata8_last(uint8_t c) __attribute__((always_inline)) {
-		maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(7));
+		maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
 		_pimxrt_spi->TDR = c;
 //		_pimxrt_spi->SR = LPSPI_SR_WCF | LPSPI_SR_FCF | LPSPI_SR_TCF;
 		pending_rx_count++;	//
 		waitTransmitComplete();
 	}
 	void writedata16_last(uint16_t d) __attribute__((always_inline)) {
-		maybeUpdateTCR(LPSPI_TCR_PCS(1) | LPSPI_TCR_FRAMESZ(15));
+		maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(15));
 		_pimxrt_spi->TDR = d;
 //		_pimxrt_spi->SR = LPSPI_SR_WCF | LPSPI_SR_FCF | LPSPI_SR_TCF;
 		pending_rx_count++;	//
@@ -851,8 +856,7 @@ class ILI9341_t3n : public Print
 #endif
 
 	#ifdef ENABLE_ILI9341_FRAMEBUFFER
-	void clearChangedRange()
-		__attribute__((always_inline)) {
+	void clearChangedRange() {
 		_changed_min_x = 0x7fff;
 		_changed_max_x = -1;
 		_changed_min_x = 0x7fff;

--- a/examples/Kurts_ILI9341_t3n_FB_and_clip_tests/Kurts_ILI9341_t3n_FB_and_clip_tests.ino
+++ b/examples/Kurts_ILI9341_t3n_FB_and_clip_tests/Kurts_ILI9341_t3n_FB_and_clip_tests.ino
@@ -1,10 +1,24 @@
+#include <Adafruit_GFX.h>    // Core graphics library
 #include <ili9341_t3n_font_Arial.h>
 #include <ili9341_t3n_font_ArialBold.h>
 #include <ILI9341_t3n.h>
+#include <Fonts/FreeMonoBoldOblique12pt7b.h>
+#include <Fonts/FreeSerif12pt7b.h>
 
-#include <SPIN.h>
+#define ROTATION 3
+
 #include "SPI.h"
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x 
+#define TFT_DC  9  // only CS pin 
+#define TFT_CS 10  // using standard pin
+#define TFT_RST 8
+ILI9341_t3n tft = ILI9341_t3n(TFT_CS, TFT_DC, TFT_RST);
+#else
+//#define DEFAULT_PINS
+//#define USE_SPI1
 #define KURTS_FLEXI
+//#define FRANKS_C64
+
 #ifdef KURTS_FLEXI
 #define TFT_DC 22
 #define TFT_CS 15
@@ -13,19 +27,57 @@
 #define TFT_MISO 12
 #define TFT_MOSI 7
 #define DEBUG_PIN 13
-#else
+
+#elif defined(FRANKS_C64)
+#define SCK       14
+#define MISO      39
+#define MOSI      28
+#define TFT_TOUCH_CS    38
+#define TFT_TOUCH_INT   37
+#define TFT_DC          20
+#define TFT_CS          21
+#define TFT_RST        -1  // 255 = unused, connected to 3.3V
+#define TFT_SCK        SCK
+#define TFT_MOSI        MOSI
+#define TFT_MISO        MISO
+
+#elif defined(DEFAULT_PINS)
 #define TFT_DC  9
+#define TFT_CS 10
+#define TFT_RST 8
+#define TFT_SCK 13
+#define TFT_MISO 12
+#define TFT_MOSI 11
+
+#elif defined(USE_SPI1)
+#define TFT_DC 31
+#define TFT_CS 10 // any pin will work not hardware
+#define TFT_RST 8
+#define TFT_SCK 32
+#define TFT_MISO 5
+#define TFT_MOSI 21
+#define DEBUG_PIN 13
+#else
+//#define TFT_DC  9
+#define TFT_DC 45
 #define TFT_CS 10
 #define TFT_RST 7
 #define TFT_SCK 13
 #define TFT_MISO 12
 #define TFT_MOSI 11
 #endif
-ILI9341_t3n tft = ILI9341_t3n(TFT_CS, TFT_DC, TFT_RST, TFT_MOSI, TFT_SCK, TFT_MISO, &SPIN);
+ILI9341_t3n tft = ILI9341_t3n(TFT_CS, TFT_DC, TFT_RST, TFT_MOSI, TFT_SCK, TFT_MISO);
+#endif
+
 Adafruit_GFX_Button button;
-uint8_t use_fb = 0;
+
+// Let's allocate the frame buffer ourself.
+DMAMEM uint16_t tft_frame_buffer[ILI9341_TFTWIDTH * ILI9341_TFTHEIGHT];
+
+uint8_t use_dma = 0;
 uint8_t use_clip_rect = 0;
 uint8_t use_set_origin = 0;
+uint8_t use_fb = 0;
 
 #define ORIGIN_TEST_X 50
 #define ORIGIN_TEST_Y 50
@@ -33,8 +85,12 @@ uint8_t use_set_origin = 0;
 void setup() {
   while (!Serial && (millis() < 4000)) ;
   Serial.begin(115200);
+  //Serial.printf("Begin: CS:%d, DC:%d, MOSI:%d, MISO: %d, SCK: %d, RST: %d\n", TFT_CS, TFT_DC, TFT_MOSI, TFT_MISO, TFT_SCK, TFT_RST);
+
   tft.begin();
-  tft.setRotation(3);
+  tft.setFrameBuffer(tft_frame_buffer);
+
+  tft.setRotation(ROTATION);
   tft.fillScreen(ILI9341_BLACK);
 
   // read diagnostics (optional but can help debug problems)
@@ -52,7 +108,7 @@ void setup() {
   pinMode(DEBUG_PIN, OUTPUT);
 #endif
 
-  button.initButton(&tft, 200, 125, 100, 40, ILI9341_GREEN, ILI9341_YELLOW, ILI9341_RED, "UP", 1);
+  button.initButton(&tft, 200, 125, 100, 40, ILI9341_GREEN, ILI9341_YELLOW, ILI9341_RED, "UP", 1, 1);
 
   drawTestScreen();
 }
@@ -86,7 +142,7 @@ void SetupOrClearClipRectAndOffsets() {
 }
 
 
-uint16_t palette[16];  // Should probably be 256, but I don't use many colors...
+uint16_t palette[256];  // Should probably be 256, but I don't use many colors...
 uint16_t pixel_data[2500];
 const uint8_t pict1bpp[] = {0xff, 0xff, 0xc0, 0x03, 0xa0, 0x05, 0x90, 0x9, 0x88, 0x11, 0x84, 0x21, 0x82, 0x41, 0x81, 0x81,
                             0x81, 0x81, 0x82, 0x41, 0x84, 0x21, 0x88, 0x11, 0x90, 0x09, 0xa0, 0x05, 0xc0, 0x03, 0xff, 0xff
@@ -162,6 +218,14 @@ void drawTestScreen() {
 #endif
 
   tft.readRect(0, 0, 50, 50, pixel_data);
+  // For heck of it lets make sure readPixel and ReadRect 
+  // give us same data, maybe check along diagnal?
+  for (uint i=0; i < 50; i++) {
+    uint16_t pixel_color = tft.readPixel(i,i);
+    if (pixel_color != pixel_data[i*50+i]) {
+      Serial.printf("Read rect/pixel mismatch: %d %x %x\n", i, pixel_color,pixel_data[i*50+i]);
+    }    
+  }
 
 #ifdef DEBUG_PIN
   digitalWrite(DEBUG_PIN, LOW);
@@ -189,7 +253,7 @@ void drawTestScreen() {
   palette[0] = ILI9341_CYAN; 
   palette[1] = ILI9341_OLIVE; 
   tft.writeRect1BPP(75, 100, 16, 16, pict1bpp, palette);
-  tft.writeRect1BPP(320-90, 75, 16, 16, pict1bpp, palette);
+  tft.writeRect1BPP(320 - 90, 75, 16, 16, pict1bpp, palette);
   
   palette[2] = ILI9341_MAROON; 
   palette[3] = ILI9341_PINK; 
@@ -202,29 +266,64 @@ void drawTestScreen() {
   tft.setFontAdafruit();
   button.drawButton();
 
+  if (use_dma) {
+    tft.updateScreenAsync();
+  } else {
   tft.updateScreen();
-
+  }
   Serial.println(millis() - start_time, DEC);
 
-  use_fb = !use_fb;
+  if (use_dma && use_fb) {
+    delay(500);
+    Serial.printf("DMA error status: %x\n", DMA_ES);
+  }
+
+  use_fb = use_fb ? 0 : 1 ;
+  Serial.println(use_fb, DEC);
+
 
 }
 
+void fillScreenTest() {
+  tft.useFrameBuffer(0);
+  SetupOrClearClipRectAndOffsets();
+
+  tft.fillScreen(ILI9341_RED);
+  WaitForUserInput();
+  tft.fillScreen(ILI9341_GREEN);
+  WaitForUserInput();
+  tft.fillScreen(ILI9341_WHITE);
+  WaitForUserInput();
+  tft.fillScreen(ILI9341_BLACK);
+
+}
+void printTextSizes(const char *sz) {
+  Serial.printf("%s(%d,%d): SPL:%u ", sz, tft.getCursorX(), tft.getCursorY(), tft.strPixelLen(sz));
+  int16_t x, y;
+  uint16_t w, h;
+  tft.getTextBounds(sz, tft.getCursorX(), tft.getCursorY(), &x, &y, &w, &h);
+  Serial.printf(" Rect(%d, %d, %u %u)\n", x, y, w, h);  
+  tft.drawRect(x, y, w, h, ILI9341_GREEN);
+}
+
+
 void drawTextScreen(bool fOpaque) {
   SetupOrClearClipRectAndOffsets();
+  tft.setTextSize(1);
   uint32_t start_time = millis();
   tft.useFrameBuffer(use_fb);
   tft.fillScreen(use_fb ? ILI9341_RED : ILI9341_BLACK);
-  tft.setFont(Arial_40_Bold);
+  tft.setFont(Arial_28_Bold);
+//t  tft.setFont(Arial_40_Bold);
   if (fOpaque)
     tft.setTextColor(ILI9341_WHITE, use_fb ? ILI9341_BLACK : ILI9341_RED);
   else
     tft.setTextColor(ILI9341_WHITE);
   tft.setCursor(0, 5);
   tft.println("AbCdEfGhIj");
+#if 0
   tft.setFont(Arial_28_Bold);
   tft.println("0123456789!@#$");
-#if 1
   tft.setFont(Arial_20_Bold);
   tft.println("abcdefghijklmnopq");
   tft.setFont(Arial_14_Bold);
@@ -232,22 +331,222 @@ void drawTextScreen(bool fOpaque) {
   tft.setFont(Arial_10_Bold);
   tft.println("0123456789zyxwvutu");
 #endif
+  tft.setFont(&FreeMonoBoldOblique12pt7b);
+  printTextSizes("AdaFruit_MB_12");
+  if (fOpaque){
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("A");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.print("d");
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("a");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.print("F");
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("R");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.print("u");
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("i");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.print("t");
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("_");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.print("M");
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("B");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.print("_");
+    tft.setTextColor(ILI9341_RED, ILI9341_BLUE);
+    tft.print("1");
+    tft.setTextColor(ILI9341_WHITE, ILI9341_GREEN);
+    tft.println("2");
+    tft.setTextColor(ILI9341_WHITE, use_fb ? ILI9341_BLACK : ILI9341_RED);
+  }
+  else tft.println("AdaFruit_MB_12");
+  tft.setFont(&FreeSerif12pt7b);
+  printTextSizes("FreeSan12");
+  tft.println("FreeSan12");
+  tft.println();
+  tft.setTextSize(1,3);
+  printTextSizes("Size 1,3");
+  tft.println("Size 1,3");
+  tft.setFont();
+  tft.setCursor(0, 190);
+  tft.setTextSize(1,2);
+  printTextSizes("Sys(1,2)");
+  tft.println("Sys(1,2)");
+  tft.setTextSize(1);
+  printTextSizes("System");
+  tft.println("System");
+  tft.setTextSize(1);
+
+
+  tft.updateScreen();
+  Serial.printf("Use FB: %d OP: %d, DT: %d OR: %d\n", use_fb, fOpaque, use_set_origin, millis() - start_time);
+}
+
+
+void drawGFXTextScreen(bool fOpaque) {
+  SetupOrClearClipRectAndOffsets();
+  tft.setTextSize(1);
+  tft.setCursor(0, 10);
+  if (fOpaque)
+    tft.setTextColor(ILI9341_WHITE, use_fb ? ILI9341_BLACK : ILI9341_RED);
+  else
+    tft.setTextColor(ILI9341_WHITE);
+  uint32_t start_time = millis();
+  tft.useFrameBuffer(use_fb);
+  tft.fillScreen(use_fb ? ILI9341_RED : ILI9341_BLACK);
+  tft.setFont(&FreeMonoBoldOblique12pt7b);
+  tft.println("MonoBold");
+  tft.println("ABCDEFGHIJKLMNO");
+  tft.println("abcdefghijklmno");
+  tft.println("0123456789!@#$%^&*()_");
+  tft.setFont(&FreeSerif12pt7b);
+  tft.println("Serif12");
+  tft.println("ABCDEFGHIJKLMNO");
+  tft.println("abcdefghijklmno");
+  tft.println("0123456789!@#$%^&*()_");
+  tft.updateScreen();
+  tft.setTextSize(1);
+  tft.setFont();
+  Serial.printf("Use FB: %d OP: %d, DT: %d\n", use_fb, fOpaque, millis() - start_time);
+}
+//=============================================================================
+// Wait for user input
+//=============================================================================
+void WaitForUserInput() {
+  Serial.println("Hit Enter to continue");
+  Serial.flush();
+  while (Serial.read() == -1) ;
+  while (Serial.read() != -1) ;
+
+}
+
+//=============================================================================
+// Try continuous update
+//=============================================================================
+void WaitForFrame(bool fCont, uint32_t wait_frame_count) {
+  if (fCont) {
+    while (tft.frameCount() < wait_frame_count) yield();
+  } else {
+    tft.updateScreenAsync();
+    WaitForUserInput();
+  }
+}
+
+void testDMAContUpdate(bool fCont) {
+  // Force frame buffer on
+
+  Serial.printf("continuous DMA udpate test - Frame mode on\n"); Serial.flush();
+  if (!fCont) {
+    Serial.println("Step Mode");
+    Serial.flush();
+  }
+  use_fb = 1; //
+
+  tft.useFrameBuffer(use_fb);
+  tft.fillScreen(ILI9341_GREEN);
+
+  // check to see if screen memory actually turned green.
+  if (use_fb) {
+    uint16_t *pw = tft.getFrameBuffer();
+    int error_count = 0;
+    for (int i = 0; i < (ILI9341_TFTWIDTH * ILI9341_TFTHEIGHT); i++)
+    {
+      if (*pw != ILI9341_GREEN) {
+        Serial.printf("tft.fillScreen(ILI9341_GREEN) not green? %d != %x\n", i, *pw);
+        error_count++;
+      }
+      pw++;
+    }
+    Serial.printf("tft.fillScreen(ILI9341_GREEN(%x)) error count = %d\n", ILI9341_GREEN, error_count);
+  }
+
+  if (fCont)
+    tft.updateScreenAsync(fCont);
+
+  // Start the update
+  WaitForFrame(fCont, 10);
+
+  tft.fillScreen(ILI9341_YELLOW);
+  tft.drawRect(5, 5, 310, 230, ILI9341_GREEN);
+  tft.fillRect(140, 100, 40, 40, ILI9341_BLUE);
+  WaitForFrame(fCont, 20);
+
+  tft.fillScreen(ILI9341_RED);
+  tft.drawRect(5, 5, 310, 230, ILI9341_WHITE);
+
+  WaitForFrame(fCont, 30);
+
+  tft.fillScreen(ILI9341_BLACK);
+
+  tft.drawRect(5, 5, 310, 230, ILI9341_GREEN);
+  tft.drawRect(25, 25, 270, 190, ILI9341_RED);
+  WaitForFrame(fCont, 40);
+
+  digitalWrite(0, HIGH);
+  tft.drawRect(5, 5, 310, 230, ILI9341_GREEN);
+  tft.setCursor(10, 100);
+  tft.setTextColor(ILI9341_RED, ILI9341_BLACK);
+  tft.setFont(Arial_20_Bold);
+  tft.println("DONE");
+  tft.setFont();
+  tft.setCursor(10, 200);
+  tft.setTextColor(ILI9341_GREEN);
+  tft.print("Done");
+  tft.setTextSize(2);
+  tft.setCursor(10, 50);
+  tft.setTextColor(ILI9341_WHITE, ILI9341_RED);
+  tft.print("Done");
+  digitalWrite(0, LOW);
+  WaitForFrame(fCont, 45);
+  tft.fillRect(0, 0, 2, 2, ILI9341_PURPLE);
+
+  if (!fCont) {
+    Serial.println("Lets now try doing Continue for a few iterations to see if it changes");
+    tft.updateScreenAsync(true);
+    while (tft.frameCount() < 10) yield();
+  }
+  tft.endUpdateAsync();
+  Serial.println("after endUpdateAsync");
+  tft.waitUpdateAsyncComplete();
+  Serial.println("after waitUpdateAsyncComplete");
+  Serial.println("Finished test");
+
+  delay(2000);
+  Serial.println("Do normal update to see if data is there");
   tft.updateScreen();
 
-  Serial.printf("Use FB: %d OP: %d, DT: %d OR: %d\n", use_fb, fOpaque, use_set_origin, millis() - start_time);
 }
 
 void loop(void) {
   // See if any text entered
   int ich;
   if ((ich = Serial.read()) != -1) {
-    while (Serial.read() != -1) ;
+    while (Serial.read() != -1) delay(1);
+
+    // See if We have a dma operation in progress?
+    if (tft.asyncUpdateActive()) {
+      Serial.printf("Async Update active DMA error status: %x\n", DMA_ES);
+      //tft.dumpDMASettings();
+    }
+
     if (ich == 'c') {
       use_clip_rect = !use_clip_rect;
       if (use_clip_rect) Serial.println("Clip Rectangle Turned on");
       else Serial.println("Clip Rectangle turned off");
       return;
     }
+    if (ich == 'd') {
+      use_dma = !use_dma;
+      if (use_dma) Serial.println("DMA Turned on");
+      else Serial.println("DMA turned off");
+      return;
+    }
+
     if (ich == 's') {
       use_set_origin = !use_set_origin;
       if (use_set_origin) Serial.printf("Set origin to %d, %d\n", ORIGIN_TEST_X, ORIGIN_TEST_Y);
@@ -256,8 +555,20 @@ void loop(void) {
     }
     if (ich == 'o')
       drawTextScreen(1);
+    else if (ich == 'f')
+      fillScreenTest();
     else if (ich == 't')
       drawTextScreen(0);
+    else if (ich == 'g')
+      drawGFXTextScreen(0);
+    else if (ich == 'r') {
+      testDMAContUpdate(true);
+      Serial.println("Returned from testDMAContUpdate");
+    }
+    else if (ich == 'a') {
+      testDMAContUpdate(false);
+      Serial.println("Returned from testDMAContUpdate");
+    }
     else
       drawTestScreen();
   }

--- a/keywords.txt
+++ b/keywords.txt
@@ -77,6 +77,7 @@ updateScreenAsync	KEYWORD2
 waitUpdateAsyncComplete	KEYWORD2
 endUpdateAsync	KEYWORD2
 updateChangedAreasOnly	KEYWORD2
+clearChangedRange	KEYWORD2;
 frameCount	KEYWORD2
 asyncUpdateActive	KEYWORD2
 freeFrameBuffer	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -76,6 +76,7 @@ updateScreen	KEYWORD2
 updateScreenAsync	KEYWORD2
 waitUpdateAsyncComplete	KEYWORD2
 endUpdateAsync	KEYWORD2
+updateChangedAreasOnly	KEYWORD2
 frameCount	KEYWORD2
 asyncUpdateActive	KEYWORD2
 freeFrameBuffer	KEYWORD2


### PR DESCRIPTION
Add in the support for async updates using only changed rectangles. 

Also merged in support for T4.x where DC is on hardware CS pins.  

Issue was that T4.1 will have multiple hardware CS pins on the SPI object, which would not have worked with the way I originally did it. 