### PR TITLE
Fix compile issues with file name and conflict with STL containers

### DIFF
--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -2366,12 +2366,12 @@ void ILI9341_t3n::drawLine(int16_t x0, int16_t y0,
 
 	bool steep = abs(y1 - y0) > abs(x1 - x0);
 	if (steep) {
-		swap(x0, y0);
-		swap(x1, y1);
+		ILI9341_swap(x0, y0);
+		ILI9341_swap(x1, y1);
 	}
 	if (x0 > x1) {
-		swap(x0, x1);
-		swap(y0, y1);
+		ILI9341_swap(x0, x1);
+		ILI9341_swap(y0, y1);
 	}
 
 	int16_t dx, dy;
@@ -2508,13 +2508,13 @@ void ILI9341_t3n::fillTriangle ( int16_t x0, int16_t y0,
 
   // Sort coordinates by Y order (y2 >= y1 >= y0)
   if (y0 > y1) {
-    swap(y0, y1); swap(x0, x1);
+    ILI9341_swap(y0, y1); ILI9341_swap(x0, x1);
   }
   if (y1 > y2) {
-    swap(y2, y1); swap(x2, x1);
+    ILI9341_swap(y2, y1); ILI9341_swap(x2, x1);
   }
   if (y0 > y1) {
-    swap(y0, y1); swap(x0, x1);
+    ILI9341_swap(y0, y1); ILI9341_swap(x0, x1);
   }
 
   if(y0 == y2) { // Handle awkward all-on-same-line case as its own thing
@@ -2555,7 +2555,7 @@ void ILI9341_t3n::fillTriangle ( int16_t x0, int16_t y0,
     a = x0 + (x1 - x0) * (y - y0) / (y1 - y0);
     b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
     */
-    if(a > b) swap(a,b);
+    if(a > b) ILI9341_swap(a,b);
     drawFastHLine(a, y, b-a+1, color);
   }
 
@@ -2572,7 +2572,7 @@ void ILI9341_t3n::fillTriangle ( int16_t x0, int16_t y0,
     a = x1 + (x2 - x1) * (y - y1) / (y2 - y1);
     b = x0 + (x2 - x0) * (y - y0) / (y2 - y0);
     */
-    if(a > b) swap(a,b);
+    if(a > b) ILI9341_swap(a,b);
     drawFastHLine(a, y, b-a+1, color);
   }
 }

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -989,8 +989,8 @@ class ILI9341_t3n : public Print
 
 };
 
-#ifndef swap
-#define swap(a, b) { typeof(a) t = a; a = b; b = t; }
+#ifndef ILI9341_swap
+#define ILI9341_swap(a, b) { typeof(a) t = a; a = b; b = t; }
 #endif
 
 // To avoid conflict when also using Adafruit_GFX or any Adafruit library

--- a/src/ili9341_t3n_font_ComicSansMS.c
+++ b/src/ili9341_t3n_font_ComicSansMS.c
@@ -1,4 +1,4 @@
-#include "ILI9341_t3n_font_ComicSansMS.h"
+#include "ili9341_t3n_font_ComicSansMS.h"
 
 static const unsigned char ComicSansMS_8_data[] = {
 0x00,0x00,0x0C,0x03,0x24,0x0F,0x62,0x06,0x65,0x56,


### PR DESCRIPTION
The ILI9341 library is notorious for causing conflicts with STL containers like vector who have swap() as a member function. The internally defined swap function in this library must use a unique name to avoid naming collisions.