### PR TITLE
fix DrawString 1

### DIFF
--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -4996,7 +4996,7 @@ int16_t ILI9341_t3n::drawString(const String &string, int poX, int poY) {
   int16_t len = string.length() + 2;
   char buffer[len];
   string.toCharArray(buffer, len);
-  return drawString1(buffer, len, poX, poY);
+  return drawString1(buffer, len-2, poX, poY);
 }
 
 int16_t ILI9341_t3n::drawString1(char string[], int16_t len, int poX, int poY) {
@@ -5072,14 +5072,14 @@ int16_t ILI9341_t3n::drawString1(char string[], int16_t len, int poX, int poY) {
     // if (poY+cheight-baseline >_height) poY = _height - cheight;
   }
   if (font == NULL) {
-    for (uint8_t i = 0; i < len - 2; i++) {
+    for (uint8_t i = 0; i < len; i++) {
       drawChar((int16_t)(poX + sumX), (int16_t)poY, string[i], textcolor,
                textbgcolor, textsize_x, textsize_y);
-      sumX += cwidth / (len - 2) + padding;
+      sumX += cwidth / len + padding;
     }
   } else {
     setCursor(poX, poY);
-    for (uint8_t i = 0; i < len - 2; i++) {
+    for (uint8_t i = 0; i < len; i++) {
       drawFontChar(string[i]);
       setCursor(cursor_x, cursor_y);
     }

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -4999,7 +4999,7 @@ int16_t ILI9341_t3n::drawString(const String &string, int poX, int poY) {
   return drawString1(buffer, len-2, poX, poY);
 }
 
-int16_t ILI9341_t3n::drawString1(char string[], int16_t len, int poX, int poY) {
+int16_t ILI9341_t3n::drawString1(const char string[], int16_t len, int poX, int poY) {
   int16_t sumX = 0;
   uint8_t padding = 1 /*, baseline = 0*/;
 

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -467,7 +467,7 @@ public:
   int16_t drawFloat(float floatNumber, int decimal, int poX, int poY);
   // Handle char arrays
   int16_t drawString(const String &string, int poX, int poY);
-  int16_t drawString1(char string[], int16_t len, int poX, int poY);
+  int16_t drawString1(const char string[], int16_t len, int poX, int poY);
 
   void setTextDatum(uint8_t datum);
 


### PR DESCRIPTION
Before the only caller was drawString which padded the length passed in to add 2, so drawString1 reduced count by 2...

Instead pass in correct count from drawString...

I think this is the only thing needed to fix #33?

@mjs513 - does this look correct? 

Could just remove it from PDF, but makes sense to have method where I pass in buffers as I always avoid using Strings...

Note: wonder why it was not also just an overload of the drawString method like:
```
int16_t ILI9341_t3n::drawString(const char string[], int16_t len, int poX, int poY) {
```
Also if this is correct, probably need to check/fix in ili9488_t3, HX.... 