### PR TITLE
Draw string2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This library borrows some concepts and functionality from other libraries as wel
     int16_t  drawNumber(long long_num,int poX, int poY);
     int16_t  drawFloat(float floatNumber,int decimal,int poX, int poY);   
     int16_t drawString(const String& string, int poX, int poY);
-    int16_t drawString1(char string[], int16_t len, int poX, int poY);
+    int16_t drawString(char string[], int16_t len, int poX, int poY);
     void setTextDatum(uint8_t datum);
 ```
 

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -4081,7 +4081,8 @@ void ILI9341_t3n::drawFontChar(unsigned int c) {
 }
 
 // strPixelLen			- gets pixel length of given ASCII string
-int16_t ILI9341_t3n::strPixelLen(const char *str) {
+// note, it will exit if end of str or cb has been reached. 
+int16_t ILI9341_t3n::strPixelLen(const char *str, uint16_t cb) {
   //	//Serial.printf("strPixelLen %s\n", str);
   if (!str)
     return (0);
@@ -4090,12 +4091,14 @@ int16_t ILI9341_t3n::strPixelLen(const char *str) {
     // them...
     int16_t x, y;
     uint16_t w, h;
-    getTextBounds(str, cursor_x, cursor_y, &x, &y, &w, &h);
+    if (cb == 0xffff) getTextBounds(str, cursor_x, cursor_y, &x, &y, &w, &h);  // default no count passed in
+    else getTextBounds((const uint8_t *)str, cb, cursor_x, cursor_y, &x, &y, &w, &h);
     return w;
   }
 
   uint16_t len = 0, maxlen = 0;
-  while (*str) {
+  while (*str && cb) {
+    cb--; // handle case where user passes in string...
     if (*str == '\n') {
       if (len > maxlen) {
         maxlen = len;
@@ -5004,7 +5007,7 @@ int16_t ILI9341_t3n::drawString1(const char string[], int16_t len, int poX, int 
   uint8_t padding = 1 /*, baseline = 0*/;
 
   uint16_t cwidth =
-      strPixelLen(string); // Find the pixel width of the string in the font
+      strPixelLen(string, len); // Find the pixel width of the string in the font
   uint16_t cheight = textsize_y * 6;
 
   if (textdatum || padX) {

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -4999,10 +4999,10 @@ int16_t ILI9341_t3n::drawString(const String &string, int poX, int poY) {
   int16_t len = string.length() + 2;
   char buffer[len];
   string.toCharArray(buffer, len);
-  return drawString1(buffer, len-2, poX, poY);
+  return drawString(buffer, len-2, poX, poY);
 }
 
-int16_t ILI9341_t3n::drawString1(const char string[], int16_t len, int poX, int poY) {
+int16_t ILI9341_t3n::drawString(const char string[], int16_t len, int poX, int poY) {
   int16_t sumX = 0;
   uint8_t padding = 1 /*, baseline = 0*/;
 

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -467,7 +467,7 @@ public:
   int16_t drawFloat(float floatNumber, int decimal, int poX, int poY);
   // Handle char arrays
   int16_t drawString(const String &string, int poX, int poY);
-  int16_t drawString1(const char string[], int16_t len, int poX, int poY);
+  int16_t drawString(const char string[], int16_t len, int poX, int poY);
 
   void setTextDatum(uint8_t datum);
 

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -458,7 +458,7 @@ public:
                      int16_t *y1, uint16_t *w, uint16_t *h);
   void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,
                      int16_t *y1, uint16_t *w, uint16_t *h);
-  int16_t strPixelLen(const char *str);
+  int16_t strPixelLen(const char *str, uint16_t cb=0xffff);  // optional number of characters...
 
   // added support for drawing strings/numbers/floats with centering
   // modified from tft_ili9341_ESP github library


### PR DESCRIPTION
drawString1 -> drawString (overload of method)

strPixelLen takes optional cb (count of bytes) which we pass in from drawString.