### PR TITLE
Add measureTextWidth/Height

### DIFF
--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -4376,6 +4376,23 @@ void ILI9341_t3n::getTextBounds(const String &str, int16_t x, int16_t y,
   }
 }
 
+uint16_t ILI9341_t3n::measureTextWidth(const uint8_t* text, int n) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  if (n == 0)  n = strlen((const char *)text);
+  getTextBounds(text, n, 0, 0, &x1, &y1, &w, &h);
+  return w;
+}
+
+uint16_t ILI9341_t3n::measureTextHeight(const uint8_t* text, int n) {
+  int16_t x1, y1;
+  uint16_t w, h;
+  if (n == 0)  n = strlen((const char *)text);
+  getTextBounds(text, n, 0, 0, &x1, &y1, &w, &h);
+  return h;
+}
+
+
 void ILI9341_t3n::drawFontPixel(uint8_t alpha, uint32_t x, uint32_t y) {
   // Adjust alpha based on the number of alpha levels supported by the font
   // (based on bpp)

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -470,6 +470,9 @@ public:
   void getTextBounds(const String &str, int16_t x, int16_t y, int16_t *x1,
                      int16_t *y1, uint16_t *w, uint16_t *h);
   int16_t strPixelLen(const char *str, uint16_t cb=0xffff);  // optional number of characters...
+  // Added for compatibility with ILI9341_t3
+  uint16_t measureTextWidth(const uint8_t* text, int chars = 0);
+  uint16_t measureTextHeight(const uint8_t* text, int chars = 0);
 
   // added support for drawing strings/numbers/floats with centering
   // modified from tft_ili9341_ESP github library


### PR DESCRIPTION
resolves: #46

Added in the two methods for more compatibility with ili9341_t3 driver.  Note: These are simply calling the method getTextBounds, which has additional functionality.