### PR TITLE
Multi-display coexistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ unlike some other libraries.  Likewise it is setup to hopefully work with severa
 to try to match which display library you are using. 
 
 
+Co-existence with other display types
+----
+This driver attempts to co-exist with other ILI9341, GC9A01A 
+and ST77xx displays sharing the same SPI bus and DMA channel, 
+without impacting the speed optimisations too badly.
+
+Each display can share all pins _except_ the /CS pin. To share the
+/RST pin it should be specified as not connected (`-1`) for all displays,
+and then driven by user code.
+
+User code must of course ensure that accesses to different displays do not
+overlap. This is usually only an issue with async updates, as updates that write directly to a display will block until complete. For small displays, or a Teensy 4.x with PSRAM, multiple frame buffers can be used and written to while another frame buffer is being updated to its display asynchronously.
+
 
 Discussion regarding this optimized version:
 ==========================
@@ -144,12 +157,12 @@ addition are setup to support the displays that are sold by PJRC, which include:
 	http://pjrc.com/store/display_ili9341.html
 	http://pjrc.com/store/display_ili9341_touch.html
 
-Note: this library like the ILI9341_t3 library which it is derived from no longer  require any of the Adafruit libraries, such as their Adafruit_ILI9341 and Adafruit_GFX libraries APIS are based on.
+Note: this library like the ILI9341_t3 library which it is derived from no longer  require any of the Adafruit libraries, such as their Adafruit_ILI9341 and Adafruit_GFX libraries APIS are based on, but...
 
 Adafruit library info
 =======================
 
-But as this code is based of of their work, their original information is included below:
+...as this code is based of of their work, their original information is included below:
 
 ------------------------------------------
 

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ILI9341_t3n
-version=1.1.2
+version=1.2.0
 author=Limor Fried, Adafruit, Paul Stoffregen, Kurt Eckhardt
 maintainer=Kurt Eckhardt
-sentence=Optimized ILI9341 (320x240 Color TFT) Display Support different SPI buses
-paragraph=ILI9341 display support for Teensy(PJRC) T3.x and T4.x boards
+sentence=Optimized ILI9341 (320x240 Color TFT) Display 
+paragraph=Supports different SPI buses for Teensy(PJRC) T3.x and T4.x boards
 category=Display
 url=https://github.com/KurtE/ILI9341_t3n
 architectures=*

--- a/src/DisplaySharedSPIStatus.h
+++ b/src/DisplaySharedSPIStatus.h
@@ -27,6 +27,7 @@ class DisplaySharedSPIStatus
     // SPI port status to be shared across instances
     struct status_s 
     {
+        bool _begin_done = false;
         uint8_t _pending_rx_count = 0;
         uint32_t _spi_tcr_current = 0; 
     } status[NUM_SPI];

--- a/src/DisplaySharedSPIStatus.h
+++ b/src/DisplaySharedSPIStatus.h
@@ -1,0 +1,37 @@
+/*
+ * Singleton class designed to share SPI status between
+ * multiple TFT display instances.
+ * 
+ * There needs to be a copy of this header in every display
+ * driver library, but they MUST be identical
+ */
+#if !defined(_DISPLAY_SHARED_SPI_STATUS_H_)
+#define _DISPLAY_SHARED_SPI_STATUS_H_
+
+class DisplaySharedSPIStatus 
+{
+    static const int NUM_SPI = 3;
+    DisplaySharedSPIStatus() {} // Constructor is private
+  public:
+    static DisplaySharedSPIStatus& getInstance()
+    {
+        static DisplaySharedSPIStatus instance; // Guaranteed to be destroyed.
+                              // Instantiated on first use.
+        return instance;
+    }
+
+    // Delete the methods we don't want.
+    DisplaySharedSPIStatus(DisplaySharedSPIStatus const&) = delete;
+    void operator=(DisplaySharedSPIStatus const&)  = delete;
+
+    // SPI port status to be shared across instances
+    struct status_s 
+    {
+        uint8_t _pending_rx_count = 0;
+        uint32_t _spi_tcr_current = 0; 
+    } status[NUM_SPI];
+    status_s& operator[](uint8_t idx) 
+        { return status[idx]; }
+};
+#endif // !defined(_DISPLAY_SHARED_SPI_STATUS_H_)
+

--- a/src/DisplaySharedSPIStatus.h
+++ b/src/DisplaySharedSPIStatus.h
@@ -28,8 +28,10 @@ class DisplaySharedSPIStatus
     struct status_s 
     {
         bool _begin_done = false;
+        volatile uint8_t _dma_state = 0;
         uint8_t _pending_rx_count = 0;
         uint32_t _spi_tcr_current = 0; 
+        DMAChannel DMAch{false};
     } status[NUM_SPI];
     status_s& operator[](uint8_t idx) 
         { return status[idx]; }

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -83,7 +83,7 @@ DMAChannel ILI9341_t3n::_dmatx;
 DMAChannel ILI9341_t3n::_dmarx;
 uint16_t ILI9341_t3n::_dma_count_remaining;
 uint16_t ILI9341_t3n::_dma_write_size_words;
-volatile short _dma_dummy_rx;
+volatile short _dma_dummy_rx __attribute__((weak));
 #endif
 
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
@@ -2674,13 +2674,8 @@ FLASHMEM void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read) {
   uint32_t *pa = (uint32_t *)((void *)_pspi);
   _spi_hardware = (SPIClass::SPI_Hardware_t *)(void *)pa[1];
 
-  if (!_shared_spi_status[_spi_num]._begin_done)
-  {
-    _pspi->begin();
-    _shared_spi_status[_spi_num]._begin_done = true;
-    _shared_spi_status[_spi_num]._pending_rx_count = 0;
-  }
 #ifdef KINETISK
+  _pspi->begin();
   if (_pspi->pinIsChipSelect(_cs, _dc)) {
     pcs_data = _pspi->setCS(_cs);
     pcs_command = pcs_data | _pspi->setCS(_dc);
@@ -2701,6 +2696,12 @@ FLASHMEM void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read) {
     }
   }
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
+  if (!_shared_spi_status[_spi_num]._begin_done)
+  {
+    _pspi->begin();
+    _shared_spi_status[_spi_num]._begin_done = true;
+    _shared_spi_status[_spi_num]._pending_rx_count = 0;
+  }
   // Serial.println("   T4 setup CS/DC"); Serial.flush();
   _csport = portOutputRegister(_cs);
   _cspinmask = digitalPinToBitMask(_cs);
@@ -2731,6 +2732,7 @@ FLASHMEM void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read) {
 
 #else
   // TLC
+  _pspi->begin();
   pcs_data = 0;
   pcs_command = 0;
   pinMode(_cs, OUTPUT);

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -165,6 +165,7 @@ void ILI9341_t3n::process_dma_interrupt(void) {
     (*_frame_complete_callback)();
 // See if we should do call back or not...
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
+  DMAChannel& _dmatx = *_pDMAtx;
 // T4
 #ifdef DEBUG_ASYNC_UPDATE
   static uint8_t print_count;
@@ -508,6 +509,20 @@ void dumpDMA_TCD(DMABaseClass *dmabc, const char *psz_title) {
 #ifdef ENABLE_ILI9341_FRAMEBUFFER
 //==============================================
 #ifdef ENABLE_ILI9341_FRAMEBUFFER
+
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
+void ILI9341_t3n::_attachInterrupt(DMAChannel& _dmatx)
+{
+    if (_spi_num == 0)
+      _dmatx.attachInterrupt(dmaInterrupt);
+    else if (_spi_num == 1)
+      _dmatx.attachInterrupt(dmaInterrupt1);
+    else
+      _dmatx.attachInterrupt(dmaInterrupt2);
+}
+#endif // T4.x
+
+
 void ILI9341_t3n::initDMASettings(void) {
   // Serial.printf("initDMASettings called %d\n", _dma_state);
   if (_dma_state & ILI9341_DMA_INIT) { // should test for init, but...
@@ -611,18 +626,16 @@ void ILI9341_t3n::initDMASettings(void) {
 #ifdef DEBUG_ASYNC_LEDS
     digitalWriteFast(DEBUG_PIN_4, !digitalReadFast(DEBUG_PIN_4));
 #endif
+    DMAChannel& _dmatx = _shared_spi_status[_spi_num].DMAch;
+    _pDMAtx = &_dmatx;
     _dmatx = _dmasettings[0];
-    _dmatx.begin(true);
+    if (nullptr == _dmatx.TCD)
+      _dmatx.begin(true);
     _dmatx.triggerAtHardwareEvent(dmaTXevent);
 #ifdef DEBUG_ASYNC_LEDS
     digitalWriteFast(DEBUG_PIN_4, !digitalReadFast(DEBUG_PIN_4));
 #endif
-    if (_spi_num == 0)
-      _dmatx.attachInterrupt(dmaInterrupt);
-    else if (_spi_num == 1)
-      _dmatx.attachInterrupt(dmaInterrupt1);
-    else
-      _dmatx.attachInterrupt(dmaInterrupt2);
+    _attachInterrupt(_dmatx);
   }
 #ifdef DEBUG_ASYNC_LEDS
   digitalWriteFast(DEBUG_PIN_4, !digitalReadFast(DEBUG_PIN_4));
@@ -809,6 +822,7 @@ bool ILI9341_t3n::updateScreenAsync(
   _pimxrt_spi->DER = LPSPI_DER_TDDE;
   _pimxrt_spi->SR = 0x3f00; // clear out all of the other status...
 
+  DMAChannel& _dmatx = *_pDMAtx;
   _dmatx.triggerAtHardwareEvent(_spi_hardware->tx_dma_channel);
 
   _dmatx = _dmasettings[0];
@@ -816,6 +830,7 @@ bool ILI9341_t3n::updateScreenAsync(
   digitalWriteFast(DEBUG_PIN_4, !digitalReadFast(DEBUG_PIN_4));
 #endif
 
+  _attachInterrupt(_dmatx); // another screen may have hijacked it
   _dmatx.begin(false);
   _dmatx.enable();
 
@@ -5273,6 +5288,8 @@ void ILI9341_t3n::waitTransmitComplete(void) {
       tmp = _pimxrt_spi->RDR; // Read any pending RX bytes in
       _shared_spi_status[_spi_num]._pending_rx_count--;     // decrement count of bytes still levt
     }
+//    else
+//      _shared_spi_status[_spi_num]._pending_rx_count--; // do it anyway...
   }
   _pimxrt_spi->CR = LPSPI_CR_MEN | LPSPI_CR_RRF; // Clear RX FIFO
   //    digitalWriteFast(2, LOW);
@@ -5287,6 +5304,8 @@ uint16_t ILI9341_t3n::waitTransmitCompleteReturnLast() {
       val = _pimxrt_spi->RDR; // Read any pending RX bytes in
       _shared_spi_status[_spi_num]._pending_rx_count--;     // decrement count of bytes still levt
     }
+//    else
+//      _shared_spi_status[_spi_num]._pending_rx_count--; // do it anyway...
   }
   _pimxrt_spi->CR = LPSPI_CR_MEN | LPSPI_CR_RRF; // Clear RX FIFO
   return val;

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -627,10 +627,10 @@ void ILI9341_t3n::initDMASettings(void) {
     digitalWriteFast(DEBUG_PIN_4, !digitalReadFast(DEBUG_PIN_4));
 #endif
     DMAChannel& _dmatx = _shared_spi_status[_spi_num].DMAch;
-    _pDMAtx = &_dmatx;
-    _dmatx = _dmasettings[0];
     if (nullptr == _dmatx.TCD)
       _dmatx.begin(true);
+    _pDMAtx = &_dmatx;
+    _dmatx = _dmasettings[0];
     _dmatx.triggerAtHardwareEvent(dmaTXevent);
 #ifdef DEBUG_ASYNC_LEDS
     digitalWriteFast(DEBUG_PIN_4, !digitalReadFast(DEBUG_PIN_4));

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -1720,21 +1720,21 @@ if (_miso == 0xff)  return 0; // dont have miso pin
   maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
   // BUGBUG - maybe update does not hold CONT if we are handling DC as IO pin... 
   // so see if hacking it helps...
-  _pimxrt_spi->TCR = _spi_tcr_current | LPSPI_TCR_CONT;
+  _pimxrt_spi->TCR = _shared_spi_status[_spi_num]._spi_tcr_current | LPSPI_TCR_CONT;
 
   _pimxrt_spi->TDR = 0x45; // send command
-  pending_rx_count++; //
+  _shared_spi_status[_spi_num]._pending_rx_count++; //
   while (!(_pimxrt_spi->SR & LPSPI_SR_WCF)) ; // wait until word complete
   delayMicroseconds(3);
-  _pimxrt_spi->TCR = _spi_tcr_current;
+  _pimxrt_spi->TCR = _shared_spi_status[_spi_num]._spi_tcr_current;
   maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
   _pimxrt_spi->TDR = 0;
-  pending_rx_count++; //
+  _shared_spi_status[_spi_num]._pending_rx_count++; //
   maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7) );
   _pimxrt_spi->TDR = 0;
-  pending_rx_count++; //
+  _shared_spi_status[_spi_num]._pending_rx_count++; //
 //  _pimxrt_spi->TDR = 0;
-//  pending_rx_count++; //
+//  _shared_spi_status[_spi_num]._pending_rx_count++; //
 
   uint16_t line = waitTransmitCompleteReturnLast();
   endSPITransaction();
@@ -2682,12 +2682,12 @@ FLASHMEM void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read) {
   }
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
   // Serial.println("   T4 setup CS/DC"); Serial.flush();
-  pending_rx_count = 0; // Make sure it is zero if we we do a second begin...
+  _shared_spi_status[_spi_num]._pending_rx_count = 0; // Make sure it is zero if we we do a second begin...
   _csport = portOutputRegister(_cs);
   _cspinmask = digitalPinToBitMask(_cs);
   pinMode(_cs, OUTPUT);
   DIRECT_WRITE_HIGH(_csport, _cspinmask);
-  _spi_tcr_current = _pimxrt_spi->TCR; // get the current TCR value
+  _shared_spi_status[_spi_num]._spi_tcr_current = _pimxrt_spi->TCR; // get the current TCR value
 
   // TODO:  Need to setup DC to actually work.
   if (_pspi->pinIsChipSelect(_dc)) {
@@ -5245,8 +5245,8 @@ void ILI9341_t3n::waitFifoNotFull(void) {
   do {
     if ((_pimxrt_spi->RSR & LPSPI_RSR_RXEMPTY) == 0) {
       tmp = _pimxrt_spi->RDR; // Read any pending RX bytes in
-      if (pending_rx_count)
-        pending_rx_count--; // decrement count of bytes still levt
+      if (_shared_spi_status[_spi_num]._pending_rx_count)
+        _shared_spi_status[_spi_num]._pending_rx_count--; // decrement count of bytes still levt
     }
   } while ((_pimxrt_spi->SR & LPSPI_SR_TDF) == 0);
 }
@@ -5255,8 +5255,8 @@ void ILI9341_t3n::waitFifoEmpty(void) {
   do {
     if ((_pimxrt_spi->RSR & LPSPI_RSR_RXEMPTY) == 0) {
       tmp = _pimxrt_spi->RDR; // Read any pending RX bytes in
-      if (pending_rx_count)
-        pending_rx_count--; // decrement count of bytes still levt
+      if (_shared_spi_status[_spi_num]._pending_rx_count)
+        _shared_spi_status[_spi_num]._pending_rx_count--; // decrement count of bytes still levt
     }
   } while ((_pimxrt_spi->SR & LPSPI_SR_TCF) == 0);
 }
@@ -5264,10 +5264,10 @@ void ILI9341_t3n::waitTransmitComplete(void) {
   uint32_t tmp __attribute__((unused));
   //    digitalWriteFast(2, HIGH);
 
-  while (pending_rx_count) {
+  while (_shared_spi_status[_spi_num]._pending_rx_count) {
     if ((_pimxrt_spi->RSR & LPSPI_RSR_RXEMPTY) == 0) {
       tmp = _pimxrt_spi->RDR; // Read any pending RX bytes in
-      pending_rx_count--;     // decrement count of bytes still levt
+      _shared_spi_status[_spi_num]._pending_rx_count--;     // decrement count of bytes still levt
     }
   }
   _pimxrt_spi->CR = LPSPI_CR_MEN | LPSPI_CR_RRF; // Clear RX FIFO
@@ -5278,10 +5278,10 @@ uint16_t ILI9341_t3n::waitTransmitCompleteReturnLast() {
   uint32_t val=0;
   //    digitalWriteFast(2, HIGH);
 
-  while (pending_rx_count) {
+  while (_shared_spi_status[_spi_num]._pending_rx_count) {
     if ((_pimxrt_spi->RSR & LPSPI_RSR_RXEMPTY) == 0) {
       val = _pimxrt_spi->RDR; // Read any pending RX bytes in
-      pending_rx_count--;     // decrement count of bytes still levt
+      _shared_spi_status[_spi_num]._pending_rx_count--;     // decrement count of bytes still levt
     }
   }
   _pimxrt_spi->CR = LPSPI_CR_MEN | LPSPI_CR_RRF; // Clear RX FIFO

--- a/src/ILI9341_t3n.cpp
+++ b/src/ILI9341_t3n.cpp
@@ -2659,7 +2659,12 @@ FLASHMEM void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read) {
   uint32_t *pa = (uint32_t *)((void *)_pspi);
   _spi_hardware = (SPIClass::SPI_Hardware_t *)(void *)pa[1];
 
-  _pspi->begin();
+  if (!_shared_spi_status[_spi_num]._begin_done)
+  {
+    _pspi->begin();
+    _shared_spi_status[_spi_num]._begin_done = true;
+    _shared_spi_status[_spi_num]._pending_rx_count = 0;
+  }
 #ifdef KINETISK
   if (_pspi->pinIsChipSelect(_cs, _dc)) {
     pcs_data = _pspi->setCS(_cs);
@@ -2682,7 +2687,6 @@ FLASHMEM void ILI9341_t3n::begin(uint32_t spi_clock, uint32_t spi_clock_read) {
   }
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
   // Serial.println("   T4 setup CS/DC"); Serial.flush();
-  _shared_spi_status[_spi_num]._pending_rx_count = 0; // Make sure it is zero if we we do a second begin...
   _csport = portOutputRegister(_cs);
   _cspinmask = digitalPinToBitMask(_cs);
   pinMode(_cs, OUTPUT);

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -507,9 +507,9 @@ public:
   // added support to use optional Frame buffer
   enum {
     ILI9341_DMA_INIT = 0x01,
-    ILI9341_DMA_EVER_INIT = 0x08,
+    ILI9341_DMA_EVER_INIT = 0x40, // 0x08,
     ILI9341_DMA_CONT = 0x02,
-    ILI9341_DMA_FINISH = 0x04,
+    //ILI9341_DMA_FINISH = 0x04,
     ILI9341_DMA_ACTIVE = 0x80
   };
   void setFrameBuffer(uint16_t *frame_buffer);
@@ -700,13 +700,14 @@ protected:
 
   static const uint32_t _count_pixels = ILI9341_TFTWIDTH * ILI9341_TFTHEIGHT;
   DMASetting _dmasettings[3];
-  DMAChannel _dmatx;
+  DMAChannel* _pDMAtx{nullptr};
   volatile uint32_t _dma_pixel_index = 0;
   uint16_t _dma_buffer_size; // the actual size we are using <= DMA_BUFFER_SIZE;
   uint16_t _dma_cnt_sub_frames_per_frame;
   uint32_t _spi_fcr_save; // save away previous FCR register value
   static void dmaInterrupt1(void);
   static void dmaInterrupt2(void);
+  void _attachInterrupt(DMAChannel&);
 #elif defined(__MK64FX512__)
   // T3.5 - had issues scatter/gather so do just use channels/interrupts
   // and update and continue

--- a/src/ILI9341_t3n.h
+++ b/src/ILI9341_t3n.h
@@ -101,6 +101,7 @@
 #include "Arduino.h"
 #include <DMAChannel.h>
 #include <SPI.h>
+#include "DisplaySharedSPIStatus.h"
 
 #endif
 #include <stdint.h>
@@ -637,7 +638,7 @@ protected:
   void waitTransmitComplete(uint32_t mcr);
 
 #elif defined(__IMXRT1052__) || defined(__IMXRT1062__)
-  uint8_t pending_rx_count = 0; // hack ...
+  // uint8_t pending_rx_count = 0; // hack ...
   void waitFifoNotFull(void);
   void waitFifoEmpty(void);
   void waitTransmitComplete(void);
@@ -651,7 +652,8 @@ protected:
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
   uint32_t _cspinmask;
   volatile uint32_t *_csport;
-  uint32_t _spi_tcr_current;
+  // uint32_t _spi_tcr_current;
+  DisplaySharedSPIStatus& _shared_spi_status = DisplaySharedSPIStatus::getInstance();
   uint32_t _dcpinmask;
   uint32_t _tcr_dc_assert;
   uint32_t _tcr_dc_not_assert;
@@ -753,7 +755,7 @@ protected:
     _pspi->beginTransaction(SPISettings(clock, MSBFIRST, SPI_MODE0));
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
     if (!_dcport)
-      _spi_tcr_current = _pimxrt_spi->TCR; // Only if DC is on hardware CS
+      _shared_spi_status[_spi_num]._spi_tcr_current = _pimxrt_spi->TCR; // Only if DC is on hardware CS
 #endif
     if (_csport) {
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__) // Teensy 4.x
@@ -813,15 +815,15 @@ protected:
 #endif
   void maybeUpdateTCR(
       uint32_t requested_tcr_state) /*__attribute__((always_inline)) */ {
-    if ((_spi_tcr_current & TCR_MASK) != requested_tcr_state) {
-      bool dc_state_change = (_spi_tcr_current & LPSPI_TCR_PCS(3)) !=
+    if ((_shared_spi_status[_spi_num]._spi_tcr_current & TCR_MASK) != requested_tcr_state) {
+      bool dc_state_change = (_shared_spi_status[_spi_num]._spi_tcr_current & LPSPI_TCR_PCS(3)) !=
                              (requested_tcr_state & LPSPI_TCR_PCS(3));
-      _spi_tcr_current = (_spi_tcr_current & ~TCR_MASK) | requested_tcr_state;
+      _shared_spi_status[_spi_num]._spi_tcr_current = (_shared_spi_status[_spi_num]._spi_tcr_current & ~TCR_MASK) | requested_tcr_state;
       // only output when Transfer queue is empty.
       if (!dc_state_change || !_dcpinmask) {
         while ((_pimxrt_spi->FSR & 0x1f))
           ;
-        _pimxrt_spi->TCR = _spi_tcr_current; // update the TCR
+        _pimxrt_spi->TCR = _shared_spi_status[_spi_num]._spi_tcr_current; // update the TCR
 
       } else {
         waitTransmitComplete();
@@ -829,7 +831,7 @@ protected:
           DIRECT_WRITE_HIGH(_dcport, _dcpinmask);
         else
           DIRECT_WRITE_LOW(_dcport, _dcpinmask);
-        _pimxrt_spi->TCR = _spi_tcr_current &
+        _pimxrt_spi->TCR = _shared_spi_status[_spi_num]._spi_tcr_current &
                            ~(LPSPI_TCR_PCS(3) |
                              LPSPI_TCR_CONT); // go ahead and update TCR anyway?
       }
@@ -840,40 +842,40 @@ protected:
   void writecommand_cont(uint8_t c) __attribute__((always_inline)) {
     maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7) /*| LPSPI_TCR_CONT*/);
     _pimxrt_spi->TDR = c;
-    pending_rx_count++; //
+    _shared_spi_status[_spi_num]._pending_rx_count++; //
     waitFifoNotFull();
   }
   void writedata8_cont(uint8_t c) __attribute__((always_inline)) {
     maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7) | LPSPI_TCR_CONT);
     _pimxrt_spi->TDR = c;
-    pending_rx_count++; //
+    _shared_spi_status[_spi_num]._pending_rx_count++; //
     waitFifoNotFull();
   }
   void writedata16_cont(uint16_t d) __attribute__((always_inline)) {
     maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(15) | LPSPI_TCR_CONT);
     _pimxrt_spi->TDR = d;
-    pending_rx_count++; //
+    _shared_spi_status[_spi_num]._pending_rx_count++; //
     waitFifoNotFull();
   }
   void writecommand_last(uint8_t c) __attribute__((always_inline)) {
     maybeUpdateTCR(_tcr_dc_assert | LPSPI_TCR_FRAMESZ(7));
     _pimxrt_spi->TDR = c;
     //		_pimxrt_spi->SR = LPSPI_SR_WCF | LPSPI_SR_FCF | LPSPI_SR_TCF;
-    pending_rx_count++; //
+    _shared_spi_status[_spi_num]._pending_rx_count++; //
     waitTransmitComplete();
   }
   void writedata8_last(uint8_t c) __attribute__((always_inline)) {
     maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(7));
     _pimxrt_spi->TDR = c;
     //		_pimxrt_spi->SR = LPSPI_SR_WCF | LPSPI_SR_FCF | LPSPI_SR_TCF;
-    pending_rx_count++; //
+    _shared_spi_status[_spi_num]._pending_rx_count++; //
     waitTransmitComplete();
   }
   void writedata16_last(uint16_t d) __attribute__((always_inline)) {
     maybeUpdateTCR(_tcr_dc_not_assert | LPSPI_TCR_FRAMESZ(15));
     _pimxrt_spi->TDR = d;
     //		_pimxrt_spi->SR = LPSPI_SR_WCF | LPSPI_SR_FCF | LPSPI_SR_TCF;
-    pending_rx_count++; //
+    _shared_spi_status[_spi_num]._pending_rx_count++; //
     waitTransmitComplete();
   }
 


### PR DESCRIPTION
Changes intended to allow multiple SPI displays of different types (GC9A01A, ILI9341, ST77xx) to be used together, sharing everything except their individual /CS (chip select) pins. Tested on Teensy 4.1, and compiles for 3.x but untested (no hardware available).

Shared status is via a singleton class which needs to be used in _every_ display library that's required to coexist.

A few items have been renamed or renumbered to avoid clashes.

